### PR TITLE
[Subscription] Fix pending consensus request memory leak

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -53,7 +53,7 @@ public class IndexedConsensusRequest implements IConsensusRequest {
 
   public IndexedConsensusRequest(long searchIndex, List<IConsensusRequest> requests) {
     this.searchIndex = searchIndex;
-    this.requests = requests;
+    this.requests = new ArrayList<>(requests);
     this.syncIndex = -1L;
     this.serializedRequests = new ArrayList<>(requests.size());
   }
@@ -61,7 +61,7 @@ public class IndexedConsensusRequest implements IConsensusRequest {
   public IndexedConsensusRequest(
       long searchIndex, long syncIndex, List<IConsensusRequest> requests) {
     this.searchIndex = searchIndex;
-    this.requests = requests;
+    this.requests = new ArrayList<>(requests);
     this.syncIndex = syncIndex;
     this.serializedRequests = new ArrayList<>(requests.size());
   }
@@ -109,6 +109,21 @@ public class IndexedConsensusRequest implements IConsensusRequest {
       return retainedMemorySize;
     }
     return requests.stream().mapToLong(IConsensusRequest::getMemorySize).sum();
+  }
+
+  /**
+   * Releases the original request objects after their serialized buffers have been materialized.
+   * Replication only needs the serialized buffers, while subscription delivery still needs the
+   * original objects and therefore must not call this method.
+   */
+  public synchronized void clearRequests() {
+    if (requests.isEmpty()) {
+      return;
+    }
+    if (serializedRequestsBuilt) {
+      retainedMemorySize -= requests.stream().mapToLong(IConsensusRequest::getMemorySize).sum();
+    }
+    requests.clear();
   }
 
   public long getSearchIndex() {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -47,7 +47,9 @@ public class IndexedConsensusRequest implements IConsensusRequest {
   private final List<IConsensusRequest> requests;
   private final List<ByteBuffer> serializedRequests;
   private long memorySize = 0;
-  private AtomicLong referenceCnt = new AtomicLong();
+  private long retainedMemorySize = 0;
+  private boolean serializedRequestsBuilt = false;
+  private final AtomicLong referenceCnt = new AtomicLong();
 
   public IndexedConsensusRequest(long searchIndex, List<IConsensusRequest> requests) {
     this.searchIndex = searchIndex;
@@ -64,13 +66,18 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     this.serializedRequests = new ArrayList<>(requests.size());
   }
 
-  public void buildSerializedRequests() {
+  public synchronized void buildSerializedRequests() {
+    if (serializedRequestsBuilt) {
+      return;
+    }
     this.requests.forEach(
         r -> {
           ByteBuffer buffer = r.serializeToByteBuffer();
           this.serializedRequests.add(buffer);
           this.memorySize += Long.max(buffer.capacity(), r.getMemorySize());
+          this.retainedMemorySize += buffer.capacity() + r.getMemorySize();
         });
+    serializedRequestsBuilt = true;
   }
 
   @Override
@@ -88,6 +95,20 @@ public class IndexedConsensusRequest implements IConsensusRequest {
 
   public long getMemorySize() {
     return memorySize;
+  }
+
+  /**
+   * Returns the memory retained while this request object is alive.
+   *
+   * <p>Before replication serialization, the request only retains its original request objects.
+   * Afterwards it retains both the originals and the serialized buffers. Batch memory continues to
+   * use {@link #getMemorySize()} because a batch no longer owns the original requests.
+   */
+  public synchronized long getRetainedMemorySize() {
+    if (serializedRequestsBuilt) {
+      return retainedMemorySize;
+    }
+    return requests.stream().mapToLong(IConsensusRequest::getMemorySize).sum();
   }
 
   public long getSearchIndex() {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -314,14 +314,14 @@ public class IoTConsensusServerImpl {
         // So we need to use the lock to ensure the `offer()` and `incrementAndGet()` are
         // in one transaction.
         synchronized (searchIndex) {
-          final int sqCount = subscriptionQueueRegistry.size();
-          logDispatcher.offer(indexedConsensusRequest, sqCount > 0);
           // Deliver to subscription queues for real-time in-memory consumption.
           // Offer AFTER stateMachine.write() so that InsertNode has inferred types
           // and properly typed values (same timing as LogDispatcher).
-          if (sqCount > 0) {
-            subscriptionQueueRegistry.offer(indexedConsensusRequest);
-          } else if (logger.isDebugEnabled()
+          final boolean offeredToSubscription =
+              subscriptionQueueRegistry.offer(indexedConsensusRequest);
+          logDispatcher.offer(indexedConsensusRequest, offeredToSubscription);
+          if (!offeredToSubscription
+              && logger.isDebugEnabled()
               && indexedConsensusRequest.getSearchIndex() % 50 == 0) {
             // Log periodically when no subscription queues are registered
             logger.debug(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -321,6 +321,7 @@ public class IoTConsensusServerImpl {
               subscriptionQueueRegistry.offer(indexedConsensusRequest);
           logDispatcher.offer(indexedConsensusRequest, offeredToSubscription);
           if (!offeredToSubscription
+              && subscriptionQueueRegistry.isEmpty()
               && logger.isDebugEnabled()
               && indexedConsensusRequest.getSearchIndex() % 50 == 0) {
             // Log periodically when no subscription queues are registered

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -157,7 +157,6 @@ public class IoTConsensusServerImpl {
   private final ScheduledExecutorService backgroundTaskService;
   private final IoTConsensusRateLimiter ioTConsensusRateLimiter =
       IoTConsensusRateLimiter.getInstance();
-  private IndexedConsensusRequest lastConsensusRequest;
 
   // Subscription queues receive IndexedConsensusRequest in real-time from write(),
   // similar to LogDispatcher, enabling in-memory data delivery without waiting for WAL flush.
@@ -284,14 +283,13 @@ public class IoTConsensusServerImpl {
       IndexedConsensusRequest indexedConsensusRequest =
           buildIndexedConsensusRequestForLocalRequest(request);
       indexedConsensusRequest.setRoutingEpoch(currentRoutingEpoch);
-      lastConsensusRequest = indexedConsensusRequest;
       if (indexedConsensusRequest.getSearchIndex() % 100000 == 0) {
         logger.info(
             IoTConsensusMessages.DATA_REGION_INDEX_AFTER_BUILD,
             thisNode.getGroupId(),
             getMinSyncIndex(),
             indexedConsensusRequest.getSearchIndex(),
-            lastConsensusRequest.getSerializedRequests());
+            indexedConsensusRequest.getSerializedRequests());
       }
       IConsensusRequest planNode = stateMachine.deserializeRequest(indexedConsensusRequest);
       long startWriteTime = System.nanoTime();

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -157,6 +157,7 @@ public class IoTConsensusServerImpl {
   private final ScheduledExecutorService backgroundTaskService;
   private final IoTConsensusRateLimiter ioTConsensusRateLimiter =
       IoTConsensusRateLimiter.getInstance();
+  private IndexedConsensusRequest lastConsensusRequest;
 
   // Subscription queues receive IndexedConsensusRequest in real-time from write(),
   // similar to LogDispatcher, enabling in-memory data delivery without waiting for WAL flush.
@@ -283,13 +284,14 @@ public class IoTConsensusServerImpl {
       IndexedConsensusRequest indexedConsensusRequest =
           buildIndexedConsensusRequestForLocalRequest(request);
       indexedConsensusRequest.setRoutingEpoch(currentRoutingEpoch);
+      lastConsensusRequest = indexedConsensusRequest;
       if (indexedConsensusRequest.getSearchIndex() % 100000 == 0) {
         logger.info(
             IoTConsensusMessages.DATA_REGION_INDEX_AFTER_BUILD,
             thisNode.getGroupId(),
             getMinSyncIndex(),
             indexedConsensusRequest.getSearchIndex(),
-            indexedConsensusRequest.getSerializedRequests());
+            lastConsensusRequest.getSerializedRequests());
       }
       IConsensusRequest planNode = stateMachine.deserializeRequest(indexedConsensusRequest);
       long startWriteTime = System.nanoTime();
@@ -312,11 +314,11 @@ public class IoTConsensusServerImpl {
         // So we need to use the lock to ensure the `offer()` and `incrementAndGet()` are
         // in one transaction.
         synchronized (searchIndex) {
-          logDispatcher.offer(indexedConsensusRequest);
+          final int sqCount = subscriptionQueueRegistry.size();
+          logDispatcher.offer(indexedConsensusRequest, sqCount > 0);
           // Deliver to subscription queues for real-time in-memory consumption.
           // Offer AFTER stateMachine.write() so that InsertNode has inferred types
           // and properly typed values (same timing as LogDispatcher).
-          final int sqCount = subscriptionQueueRegistry.size();
           if (sqCount > 0) {
             subscriptionQueueRegistry.offer(indexedConsensusRequest);
           } else if (logger.isDebugEnabled()

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManager.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManager.java
@@ -44,32 +44,35 @@ public class IoTConsensusMemoryManager {
   }
 
   public boolean reserve(IndexedConsensusRequest request) {
-    long prevRef = request.incRef();
-    if (prevRef == 0) {
-      boolean reserved = reserve(request.getMemorySize(), true);
-      if (reserved) {
-        if (logger.isDebugEnabled()) {
-          logger.debug(
-              IoTConsensusMessages.RESERVING_BYTES_FOR_REQUEST_SUCCEEDS,
-              request.getMemorySize(),
-              request.getSearchIndex(),
-              memoryBlock.getUsedMemoryInBytes());
+    synchronized (request) {
+      long prevRef = request.incRef();
+      if (prevRef == 0) {
+        final long retainedMemorySize = request.getRetainedMemorySize();
+        boolean reserved = reserve(retainedMemorySize, true);
+        if (reserved) {
+          if (logger.isDebugEnabled()) {
+            logger.debug(
+                IoTConsensusMessages.RESERVING_BYTES_FOR_REQUEST_SUCCEEDS,
+                retainedMemorySize,
+                request.getSearchIndex(),
+                memoryBlock.getUsedMemoryInBytes());
+          }
+        } else {
+          request.decRef();
+          if (logger.isDebugEnabled()) {
+            logger.debug(
+                IoTConsensusMessages.RESERVING_BYTES_FOR_REQUEST_FAILS,
+                retainedMemorySize,
+                request.getSearchIndex(),
+                memoryBlock.getUsedMemoryInBytes());
+          }
         }
-      } else {
-        request.decRef();
-        if (logger.isDebugEnabled()) {
-          logger.debug(
-              IoTConsensusMessages.RESERVING_BYTES_FOR_REQUEST_FAILS,
-              request.getMemorySize(),
-              request.getSearchIndex(),
-              memoryBlock.getUsedMemoryInBytes());
-        }
+        return reserved;
+      } else if (logger.isDebugEnabled()) {
+        logger.debug(IoTConsensusMessages.SKIP_MEMORY_RESERVATION, request.getSearchIndex());
       }
-      return reserved;
-    } else if (logger.isDebugEnabled()) {
-      logger.debug(IoTConsensusMessages.SKIP_MEMORY_RESERVATION, request.getSearchIndex());
+      return true;
     }
-    return true;
   }
 
   public boolean reserve(Batch batch) {
@@ -108,15 +111,18 @@ public class IoTConsensusMemoryManager {
   }
 
   public void free(IndexedConsensusRequest request) {
-    long prevRef = request.decRef();
-    if (prevRef == 1) {
-      free(request.getMemorySize(), true);
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            IoTConsensusMessages.FREED_BYTES_FOR_REQUEST,
-            request.getMemorySize(),
-            request.getSearchIndex(),
-            memoryBlock.getUsedMemoryInBytes());
+    synchronized (request) {
+      long prevRef = request.decRef();
+      if (prevRef == 1) {
+        final long retainedMemorySize = request.getRetainedMemorySize();
+        free(retainedMemorySize, true);
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              IoTConsensusMessages.FREED_BYTES_FOR_REQUEST,
+              retainedMemorySize,
+              request.getSearchIndex(),
+              memoryBlock.getUsedMemoryInBytes());
+        }
       }
     }
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -184,9 +184,16 @@ public class LogDispatcher {
   }
 
   public void offer(IndexedConsensusRequest request) {
+    offer(request, true);
+  }
+
+  public void offer(IndexedConsensusRequest request, boolean keepRequestsForSubscription) {
     // we don't need to serialize and offer request when replicaNum is 1.
     if (!threads.isEmpty()) {
       request.buildSerializedRequests();
+      if (!keepRequestsForSubscription) {
+        request.clearRequests();
+      }
       synchronized (this) {
         threads.forEach(
             thread -> {
@@ -204,6 +211,10 @@ public class LogDispatcher {
               }
             });
       }
+    } else if (!keepRequestsForSubscription) {
+      // A single-replica region has no dispatcher thread, but still does not need the raw request
+      // after the state machine has applied it when subscriptions are disabled.
+      request.clearRequests();
     }
   }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/subscription/SubscriptionQueueRegistry.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/subscription/SubscriptionQueueRegistry.java
@@ -73,11 +73,14 @@ public class SubscriptionQueueRegistry {
     return new ArrayList<>(queues.values());
   }
 
-  public synchronized void offer(final IndexedConsensusRequest indexedConsensusRequest) {
+  public synchronized boolean offer(final IndexedConsensusRequest indexedConsensusRequest) {
     final int queueCount = queues.size();
     if (queueCount <= 0) {
-      return;
+      return false;
     }
+
+    // Subscription queues reserve request memory, including the serialized buffers.
+    indexedConsensusRequest.buildSerializedRequests();
 
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(
@@ -91,8 +94,10 @@ public class SubscriptionQueueRegistry {
               : indexedConsensusRequest.getRequests().get(0).getClass().getSimpleName());
     }
 
+    boolean offeredToAnyQueue = false;
     for (final BlockingQueue<IndexedConsensusRequest> queue : queues.keySet()) {
       final boolean offered = queue.offer(indexedConsensusRequest);
+      offeredToAnyQueue |= offered;
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(
             IoTConsensusMessages.LOG_OFFER_RESULT_ARG_QUEUESIZE_ARG_QUEUEREMAINING_ARG_7ADC84C2,
@@ -125,5 +130,6 @@ public class SubscriptionQueueRegistry {
         }
       }
     }
+    return offeredToAnyQueue;
   }
 }

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerTest.java
@@ -79,15 +79,18 @@ public class IoTConsensusMemoryManagerTest {
     assertEquals(20L, request.getMemorySize());
     assertEquals(30L, request.getRetainedMemorySize());
     assertEquals(1, request.getSerializedRequests().size());
+    request.clearRequests();
+    assertTrue(request.getRequests().isEmpty());
+    assertEquals(20L, request.getRetainedMemorySize());
 
     assertTrue(IoTConsensusMemoryManager.getInstance().reserve(request));
     assertTrue(IoTConsensusMemoryManager.getInstance().reserve(request));
     assertEquals(
-        30L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+        20L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
 
     IoTConsensusMemoryManager.getInstance().free(request);
     assertEquals(
-        30L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+        20L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
     IoTConsensusMemoryManager.getInstance().free(request);
     assertEquals(
         0L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
@@ -105,6 +108,17 @@ public class IoTConsensusMemoryManagerTest {
     IoTConsensusMemoryManager.getInstance().free(request);
     assertEquals(
         0L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+  }
+
+  @Test
+  public void testClearUnserializedRequest() {
+    final IndexedConsensusRequest request =
+        new IndexedConsensusRequest(
+            1, Collections.singletonList(new SizedConsensusRequest(10, 20)));
+
+    request.clearRequests();
+    assertTrue(request.getRequests().isEmpty());
+    assertEquals(0L, request.getRetainedMemorySize());
   }
 
   private void testReserveAndRelease(int numReservation) {

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.consensus.iot.logdispatcher;
 
 import org.apache.iotdb.commons.memory.AtomicLongMemoryBlock;
 import org.apache.iotdb.commons.memory.IMemoryBlock;
+import org.apache.iotdb.commons.request.IConsensusRequest;
 import org.apache.iotdb.consensus.common.request.ByteBufferConsensusRequest;
 import org.apache.iotdb.consensus.common.request.IndexedConsensusRequest;
 
@@ -47,10 +48,12 @@ public class IoTConsensusMemoryManagerTest {
     previousMemoryBlock = IoTConsensusMemoryManager.getInstance().getMemoryBlock();
     IoTConsensusMemoryManager.getInstance()
         .setMemoryBlock(new AtomicLongMemoryBlock("Test", null, memoryBlockSize));
+    IoTConsensusMemoryManager.getInstance().reset();
   }
 
   @After
   public void tearDown() throws Exception {
+    IoTConsensusMemoryManager.getInstance().reset();
     IoTConsensusMemoryManager.getInstance().setMemoryBlock(previousMemoryBlock);
   }
 
@@ -62,6 +65,46 @@ public class IoTConsensusMemoryManagerTest {
   @Test
   public void testMultiReserveAndRelease() {
     testReserveAndRelease(3);
+  }
+
+  @Test
+  public void testRawAndSerializedMemoryAreBothReservedOnce() {
+    final IndexedConsensusRequest request =
+        new IndexedConsensusRequest(
+            1, Collections.singletonList(new SizedConsensusRequest(10, 20)));
+
+    assertEquals(10L, request.getRetainedMemorySize());
+    request.buildSerializedRequests();
+    request.buildSerializedRequests();
+    assertEquals(20L, request.getMemorySize());
+    assertEquals(30L, request.getRetainedMemorySize());
+    assertEquals(1, request.getSerializedRequests().size());
+
+    assertTrue(IoTConsensusMemoryManager.getInstance().reserve(request));
+    assertTrue(IoTConsensusMemoryManager.getInstance().reserve(request));
+    assertEquals(
+        30L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+
+    IoTConsensusMemoryManager.getInstance().free(request);
+    assertEquals(
+        30L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+    IoTConsensusMemoryManager.getInstance().free(request);
+    assertEquals(
+        0L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+  }
+
+  @Test
+  public void testUnserializedRequestReservesRawMemory() {
+    final IndexedConsensusRequest request =
+        new IndexedConsensusRequest(
+            1, Collections.singletonList(new SizedConsensusRequest(10, 20)));
+
+    assertTrue(IoTConsensusMemoryManager.getInstance().reserve(request));
+    assertEquals(
+        10L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
+    IoTConsensusMemoryManager.getInstance().free(request);
+    assertEquals(
+        0L, IoTConsensusMemoryManager.getInstance().getMemoryBlock().getUsedMemoryInBytes());
   }
 
   private void testReserveAndRelease(int numReservation) {
@@ -99,5 +142,26 @@ public class IoTConsensusMemoryManagerTest {
       IoTConsensusMemoryManager.getInstance().free(indexedConsensusRequest);
     }
     assertEquals(0, IoTConsensusMemoryManager.getInstance().getMemorySizeInByte());
+  }
+
+  private static final class SizedConsensusRequest implements IConsensusRequest {
+
+    private final long rawMemorySize;
+    private final int serializedMemorySize;
+
+    private SizedConsensusRequest(final long rawMemorySize, final int serializedMemorySize) {
+      this.rawMemorySize = rawMemorySize;
+      this.serializedMemorySize = serializedMemorySize;
+    }
+
+    @Override
+    public ByteBuffer serializeToByteBuffer() {
+      return ByteBuffer.allocate(serializedMemorySize);
+    }
+
+    @Override
+    public long getMemorySize() {
+      return rawMemorySize;
+    }
   }
 }

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/subscription/SubscriptionQueueRegistryTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/subscription/SubscriptionQueueRegistryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.iot.subscription;
+
+import org.apache.iotdb.commons.request.IConsensusRequest;
+import org.apache.iotdb.consensus.common.request.IndexedConsensusRequest;
+import org.apache.iotdb.consensus.iot.SubscriptionWalRetentionPolicy;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class SubscriptionQueueRegistryTest {
+
+  @Test
+  public void testOfferWithoutQueuesDoesNotSerializeRequest() {
+    final SubscriptionQueueRegistry registry = new SubscriptionQueueRegistry("test");
+    final IndexedConsensusRequest request = newRequest();
+
+    assertFalse(registry.offer(request));
+    assertTrue(request.getSerializedRequests().isEmpty());
+  }
+
+  @Test
+  public void testOfferSerializesRequestBeforeQueueAdmission() {
+    final SubscriptionQueueRegistry registry = new SubscriptionQueueRegistry("test");
+    final InspectingQueue queue = new InspectingQueue();
+    registry.register(
+        queue,
+        new SubscriptionWalRetentionPolicy(
+            "test",
+            SubscriptionWalRetentionPolicy.UNBOUNDED,
+            SubscriptionWalRetentionPolicy.UNBOUNDED));
+    final IndexedConsensusRequest request = newRequest();
+
+    assertTrue(registry.offer(request));
+    assertEquals(1, request.getSerializedRequests().size());
+    assertEquals(1, queue.getSerializedRequestCountAtOffer());
+    assertSame(request, queue.poll());
+  }
+
+  private static IndexedConsensusRequest newRequest() {
+    return new IndexedConsensusRequest(
+        1, Collections.singletonList(new ByteBufferConsensusRequest(ByteBuffer.allocate(1))));
+  }
+
+  private static final class ByteBufferConsensusRequest implements IConsensusRequest {
+
+    private final ByteBuffer buffer;
+
+    private ByteBufferConsensusRequest(final ByteBuffer buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override
+    public ByteBuffer serializeToByteBuffer() {
+      return buffer;
+    }
+
+    @Override
+    public long getMemorySize() {
+      return buffer.capacity();
+    }
+  }
+
+  private static final class InspectingQueue extends ArrayBlockingQueue<IndexedConsensusRequest> {
+
+    private int serializedRequestCountAtOffer = -1;
+
+    private InspectingQueue() {
+      super(1);
+    }
+
+    @Override
+    public boolean offer(final IndexedConsensusRequest request) {
+      serializedRequestCountAtOffer = request.getSerializedRequests().size();
+      return super.offer(request);
+    }
+
+    private int getSerializedRequestCountAtOffer() {
+      return serializedRequestCountAtOffer;
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/consensus/ConsensusPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/consensus/ConsensusPrefetchingQueue.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.consensus.common.request.IndexedConsensusRequest;
 import org.apache.iotdb.consensus.iot.IoTConsensusServerImpl;
 import org.apache.iotdb.consensus.iot.SubscriptionWalRetentionPolicy;
 import org.apache.iotdb.consensus.iot.log.ConsensusReqReader;
+import org.apache.iotdb.consensus.iot.logdispatcher.IoTConsensusMemoryManager;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.i18n.DataNodeMiscMessages;
 import org.apache.iotdb.db.i18n.DataNodePipeMessages;
@@ -379,6 +380,9 @@ public class ConsensusPrefetchingQueue {
 
     private final Runnable wakeupHook;
     private final BooleanSupplier admissionSupplier;
+    private final IoTConsensusMemoryManager requestMemoryManager =
+        IoTConsensusMemoryManager.getInstance();
+    private final AtomicLong retainedRequestBytes = new AtomicLong(0L);
 
     private WakeableIndexedConsensusQueue(
         final int capacity, final Runnable wakeupHook, final BooleanSupplier admissionSupplier) {
@@ -394,7 +398,20 @@ public class ConsensusPrefetchingQueue {
         if (!admissionSupplier.getAsBoolean()) {
           return false;
         }
-        offered = super.offer(request);
+        if (!requestMemoryManager.reserve(request)) {
+          return false;
+        }
+        try {
+          offered = super.offer(request);
+        } catch (final Throwable t) {
+          requestMemoryManager.free(request);
+          throw t;
+        }
+        if (offered) {
+          retainedRequestBytes.addAndGet(request.getRetainedMemorySize());
+        } else {
+          requestMemoryManager.free(request);
+        }
       }
       if (offered) {
         wakeupHook.run();
@@ -404,7 +421,23 @@ public class ConsensusPrefetchingQueue {
 
     @Override
     public synchronized void clear() {
-      super.clear();
+      IndexedConsensusRequest request;
+      while (Objects.nonNull(request = super.poll())) {
+        release(request);
+      }
+    }
+
+    private void release(final IndexedConsensusRequest request) {
+      retainedRequestBytes.addAndGet(-request.getRetainedMemorySize());
+      requestMemoryManager.free(request);
+    }
+
+    private void release(final List<IndexedConsensusRequest> requests) {
+      requests.forEach(this::release);
+    }
+
+    private long getRetainedRequestBytes() {
+      return retainedRequestBytes.get();
     }
   }
 
@@ -1391,9 +1424,14 @@ public class ConsensusPrefetchingQueue {
             nextExpectedSearchIndex.get(),
             prefetchingQueue.size());
 
-        final MaterializationResult batchResult =
-            accumulateFromPending(
-                batch, lingerBatch, observedSeekGeneration, maxTablets, maxBatchBytes);
+        final MaterializationResult batchResult;
+        try {
+          batchResult =
+              accumulateFromPending(
+                  batch, lingerBatch, observedSeekGeneration, maxTablets, maxBatchBytes);
+        } finally {
+          pendingEntries.release(batch);
+        }
         if (batchResult != MaterializationResult.SUCCESS) {
           if (batchResult == MaterializationResult.WAL_GAP) {
             return PrefetchRoundResult.rescheduleAfter(WAL_GAP_RETRY_SLEEP_MS);
@@ -3812,6 +3850,10 @@ public class ConsensusPrefetchingQueue {
     return retainedTabletBytes.get();
   }
 
+  public long getRetainedRequestBytes() {
+    return pendingEntries.getRetainedRequestBytes();
+  }
+
   public long getSubscriptionMemoryLimitInBytes() {
     return subscriptionMemoryManager.getTotalMemorySizeInBytes();
   }
@@ -3880,6 +3922,7 @@ public class ConsensusPrefetchingQueue {
     result.put("prefetchingQueueSize", String.valueOf(prefetchingQueue.size()));
     result.put("inFlightEventsSize", String.valueOf(inFlightEvents.size()));
     result.put("pendingEntriesSize", String.valueOf(pendingEntries.size()));
+    result.put("retainedRequestBytes", String.valueOf(getRetainedRequestBytes()));
     result.put("retainedTabletBytes", String.valueOf(retainedTabletBytes.get()));
     result.put("memoryBlockedEntryBytes", String.valueOf(memoryBlockedEntryBytes));
     result.put("realtimeAdmissionBlocked", String.valueOf(realtimeAdmissionBlocked.get()));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/subscription/broker/consensus/ConsensusPrefetchingQueueTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/subscription/broker/consensus/ConsensusPrefetchingQueueTest.java
@@ -21,11 +21,15 @@ package org.apache.iotdb.db.subscription.broker.consensus;
 
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.commons.memory.AtomicLongMemoryBlock;
+import org.apache.iotdb.commons.memory.IMemoryBlock;
+import org.apache.iotdb.commons.request.IConsensusRequest;
 import org.apache.iotdb.consensus.common.request.IndexedConsensusRequest;
 import org.apache.iotdb.consensus.iot.IoTConsensusServerImpl;
 import org.apache.iotdb.consensus.iot.SubscriptionWalRetentionPolicy;
 import org.apache.iotdb.consensus.iot.WriterSafeFrontierTracker;
 import org.apache.iotdb.consensus.iot.log.ConsensusReqReader;
+import org.apache.iotdb.consensus.iot.logdispatcher.IoTConsensusMemoryManager;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementTestUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.io.ProgressWALReader;
@@ -56,6 +60,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -189,6 +194,54 @@ public class ConsensusPrefetchingQueueTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  public void testPendingQueueUsesSharedConsensusMemoryBudgetAndClearReleasesIt() throws Exception {
+    final Class<?> queueClass =
+        Class.forName(ConsensusPrefetchingQueue.class.getName() + "$WakeableIndexedConsensusQueue");
+    final Constructor<?> constructor =
+        queueClass.getDeclaredConstructor(int.class, Runnable.class, BooleanSupplier.class);
+    constructor.setAccessible(true);
+    final Method retainedBytesMethod = queueClass.getDeclaredMethod("getRetainedRequestBytes");
+    retainedBytesMethod.setAccessible(true);
+
+    final IoTConsensusMemoryManager memoryManager = IoTConsensusMemoryManager.getInstance();
+    final IMemoryBlock previousMemoryBlock = memoryManager.getMemoryBlock();
+    final double previousQueueRatio = memoryManager.getMaxMemoryRatioForQueue();
+    final AtomicLongMemoryBlock testMemoryBlock =
+        new AtomicLongMemoryBlock("SubscriptionPendingTest", null, 100L);
+    final BlockingQueue<IndexedConsensusRequest> firstQueue =
+        (BlockingQueue<IndexedConsensusRequest>)
+            constructor.newInstance(8, (Runnable) () -> {}, (BooleanSupplier) () -> true);
+    final BlockingQueue<IndexedConsensusRequest> secondQueue =
+        (BlockingQueue<IndexedConsensusRequest>)
+            constructor.newInstance(8, (Runnable) () -> {}, (BooleanSupplier) () -> true);
+
+    memoryManager.init(testMemoryBlock, 0.6);
+    try {
+      final IndexedConsensusRequest sharedRequest = createSizedRequest(1L, 10L, 30);
+      assertTrue(firstQueue.offer(sharedRequest));
+      assertTrue(secondQueue.offer(sharedRequest));
+      assertEquals(40L, testMemoryBlock.getUsedMemoryInBytes());
+      assertEquals(40L, retainedBytesMethod.invoke(firstQueue));
+      assertEquals(40L, retainedBytesMethod.invoke(secondQueue));
+
+      assertFalse(firstQueue.offer(createSizedRequest(2L, 10L, 30)));
+      assertEquals(40L, testMemoryBlock.getUsedMemoryInBytes());
+
+      firstQueue.clear();
+      assertEquals(40L, testMemoryBlock.getUsedMemoryInBytes());
+      assertEquals(0L, retainedBytesMethod.invoke(firstQueue));
+      secondQueue.clear();
+      assertEquals(0L, testMemoryBlock.getUsedMemoryInBytes());
+      assertEquals(0L, retainedBytesMethod.invoke(secondQueue));
+    } finally {
+      firstQueue.clear();
+      secondQueue.clear();
+      memoryManager.init(previousMemoryBlock, previousQueueRatio);
+    }
+  }
+
+  @Test
   public void testLagIncludesLingeringBatchUntilCommitted() throws Exception {
     final String originalSystemDir = IoTDBDescriptor.getInstance().getConfig().getSystemDir();
     final int originalBatchMaxDelay =
@@ -230,8 +283,13 @@ public class ConsensusPrefetchingQueueTest {
               .setNodeId(7);
 
       assertNull(queue.poll("consumer"));
-      pendingEntries(queue).offer(request);
+      assertTrue(pendingEntries(queue).offer(request));
+      assertEquals(request.getRetainedMemorySize(), queue.getRetainedRequestBytes());
+      assertEquals(
+          String.valueOf(request.getRetainedMemorySize()),
+          queue.coreReportMessage().get("retainedRequestBytes"));
       queue.drivePrefetchOnce();
+      assertEquals(0L, queue.getRetainedRequestBytes());
 
       assertEquals(0, queue.getPrefetchedEventCount());
       assertEquals(1L, queue.getLag());
@@ -1800,6 +1858,17 @@ public class ConsensusPrefetchingQueueTest {
         .setNodeId(7);
   }
 
+  private static IndexedConsensusRequest createSizedRequest(
+      final long searchIndex, final long rawMemorySize, final int serializedMemorySize) {
+    final IndexedConsensusRequest request =
+        new IndexedConsensusRequest(
+            searchIndex,
+            Collections.singletonList(
+                new SizedConsensusRequest(rawMemorySize, serializedMemorySize)));
+    request.buildSerializedRequests();
+    return request;
+  }
+
   private static ConsensusSubscriptionCommitManager newCommitManager(final File systemDir)
       throws Exception {
     IoTDBDescriptor.getInstance().getConfig().setSystemDir(systemDir.getAbsolutePath());
@@ -1848,6 +1917,27 @@ public class ConsensusPrefetchingQueueTest {
     @Override
     public Pair<Long, Long> getDeletionBoundToFreeAtLeast(final long bytesToFree) {
       return new Pair<>(DEFAULT_SAFELY_DELETED_SEARCH_INDEX, 0L);
+    }
+  }
+
+  private static final class SizedConsensusRequest implements IConsensusRequest {
+
+    private final long rawMemorySize;
+    private final int serializedMemorySize;
+
+    private SizedConsensusRequest(final long rawMemorySize, final int serializedMemorySize) {
+      this.rawMemorySize = rawMemorySize;
+      this.serializedMemorySize = serializedMemorySize;
+    }
+
+    @Override
+    public ByteBuffer serializeToByteBuffer() {
+      return ByteBuffer.allocate(serializedMemorySize);
+    }
+
+    @Override
+    public long getMemorySize() {
+      return rawMemorySize;
     }
   }
 }


### PR DESCRIPTION
## Description

### Bound pending consensus request memory

In a multi-replica region, `LogDispatcher` serializes each `IndexedConsensusRequest` before the same object is offered to subscription pending queues. A slow or paused subscription could therefore retain both the raw `InsertNode` and serialized `ByteBuffer` without participating in the IoTConsensus memory budget, causing heap growth and eventually DataNode fencing.

This PR:

- makes request serialization idempotent and exposes the retained size as raw request memory plus serialized buffer capacity;
- reuses the existing ref-counted `IoTConsensusMemoryManager`, so dispatchers and subscription queues sharing one request reserve its physical memory only once;
- rejects subscription fast-path admission when the shared queue budget is exhausted, allowing the existing WAL replay path to recover the entry;
- releases queue ownership after materialization in a `finally` block, and on offer failure, clear, deactivation, and close;
- keeps batch accounting unchanged because replication batches no longer own the raw request objects.

### Remove unnecessary retention

Remove `IoTConsensusServerImpl.lastConsensusRequest`, which kept the latest request, including a potentially large raw/serialized payload, reachable indefinitely.

### Diagnostics

Expose `retainedRequestBytes` in the subscription queue core report to make pending-request retention observable.

## Tests

- `IoTConsensusMemoryManagerTest`: 4 tests passed.
- `ConsensusPrefetchingQueueTest`, `ConsensusPrefetchingQueueDataNodeMemoryTest`, and `ConsensusPrefetchingQueueWalBackpressureTest`: 29 tests passed.
- Spotless, Checkstyle, and `git diff --check` passed.

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent write
- [x] added Javadocs for non-trivial memory accounting behavior.
- [x] added comments explaining ownership and release intent.
- [x] added or updated unit tests to cover new code paths.

<hr>

##### Key changed/added classes

- `IndexedConsensusRequest`
- `IoTConsensusMemoryManager`
- `IoTConsensusServerImpl`
- `ConsensusPrefetchingQueue`