### PR TITLE
[To dev/1.3] Update thrift to 0.23.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -236,7 +236,7 @@ org.eclipse.jetty:jetty-servlet:9.4.58.v20250814
 org.eclipse.jetty:jetty-util:9.4.58.v20250814
 com.google.code.findbugs:jsr305:3.0.2
 com.librato.metrics:librato-java:2.1.0
-org.apache.thrift:libthrift:0.14.1
+org.apache.thrift:libthrift:0.23.0
 io.dropwizard.metrics:metrics-core:4.2.19
 io.dropwizard.metrics:metrics-jvm:3.2.2
 com.librato.metrics:metrics-librato:5.1.0

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -214,6 +214,16 @@
             <artifactId>jcip-annotations</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/iotdb-client/jdbc/src/main/feature/feature.xml
+++ b/iotdb-client/jdbc/src/main/feature/feature.xml
@@ -27,7 +27,7 @@
         <bundle>mvn:org.apache.iotdb/service-rpc/${project.version}</bundle>
         <bundle>mvn:org.apache.iotdb/iotdb-thrift/${project.version}</bundle>
         <bundle>mvn:org.apache.iotdb/hadoop-tsfile/${project.version}</bundle>
-        <bundle>mvn:org.apache.thrift/libthrift/0.14.1</bundle>
+        <bundle>mvn:org.apache.thrift/libthrift/0.23.0</bundle>
         <bundle>mvn:org.xerial.snappy/snappy-java/1.1.8.4</bundle>
         <bundle>mvn:commons-io/commons-io/2.5</bundle>
         <bundle>wrap:mvn:org.apache.hadoop/hadoop-core/1.2.1</bundle>

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TNonblockingSocketWrapper.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TNonblockingSocketWrapper.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.nio.channels.SocketChannel;
 
 /**
- * In Thrift 0.14.1, TNonblockingSocket's constructor throws a never-happened exception. So, we
- * screen the exception https://issues.apache.org/jira/browse/THRIFT-5412
+ * TNonblockingSocket's constructor declares a TTransportException for compatibility, but this code
+ * path is not expected to throw one. See https://issues.apache.org/jira/browse/THRIFT-5412.
  */
 public class TNonblockingSocketWrapper {
 

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSocketWrapper.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSocketWrapper.java
@@ -24,8 +24,8 @@ import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
 
 /**
- * In Thrift 0.14.1, TSocket's constructor throws a never-happened exception. So, we screen the
- * exception https://issues.apache.org/jira/browse/THRIFT-5412
+ * TSocket's constructor declares a TTransportException for compatibility, but this code path is not
+ * expected to throw one. See https://issues.apache.org/jira/browse/THRIFT-5412.
  */
 public class TSocketWrapper {
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.iotdb.confignode.service.thrift;
 
+import org.apache.iotdb.commons.service.NoopServerContext;
 import org.apache.iotdb.commons.service.metric.MetricService;
 
 import org.apache.thrift.protocol.TProtocol;
@@ -37,7 +38,7 @@ public class ConfigNodeRPCServiceHandler implements TServerEventHandler {
   @Override
   public ServerContext createContext(TProtocol input, TProtocol output) {
     thriftConnectionNumber.incrementAndGet();
-    return null;
+    return NoopServerContext.INSTANCE;
   }
 
   @Override

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceHandler.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.consensus.iot.service;
 
+import org.apache.iotdb.commons.service.NoopServerContext;
+
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServerEventHandler;
@@ -37,7 +39,7 @@ public class IoTConsensusRPCServiceHandler implements TServerEventHandler {
 
   @Override
   public ServerContext createContext(TProtocol input, TProtocol output) {
-    return null;
+    return NoopServerContext.INSTANCE;
   }
 
   @Override

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/service/PipeConsensusRPCServiceHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/service/PipeConsensusRPCServiceHandler.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.consensus.pipe.service;
 
+import org.apache.iotdb.commons.service.NoopServerContext;
+
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServerEventHandler;
@@ -37,7 +39,7 @@ public class PipeConsensusRPCServiceHandler implements TServerEventHandler {
 
   @Override
   public ServerContext createContext(TProtocol input, TProtocol output) {
-    return null;
+    return NoopServerContext.INSTANCE;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/handler/BaseServerContextHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/handler/BaseServerContextHandler.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.protocol.thrift.handler;
 
+import org.apache.iotdb.commons.service.NoopServerContext;
 import org.apache.iotdb.db.protocol.session.ClientSession;
 import org.apache.iotdb.db.protocol.session.SessionManager;
 import org.apache.iotdb.external.api.thrift.JudgableServerContext;
@@ -62,16 +63,17 @@ public class BaseServerContextHandler {
     getSessionManager().registerSession(new ClientSession(socket));
     if (factory != null) {
       context = factory.newServerContext(out, socket);
-      if (!context.whenConnect()) {
+      if (context != null && !context.whenConnect()) {
         return context;
       }
     }
-    return context;
+    return context == null ? NoopServerContext.INSTANCE : context;
   }
 
   public void deleteContext(ServerContext context, TProtocol in, TProtocol out) {
     getSessionManager().removeCurrSession();
-    if (context != null && factory != null) {
+
+    if (context instanceof JudgableServerContext) {
       ((JudgableServerContext) context).whenDisconnect();
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/handler/InternalServiceThriftHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/handler/InternalServiceThriftHandler.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.protocol.thrift.handler;
 
+import org.apache.iotdb.commons.service.NoopServerContext;
 import org.apache.iotdb.commons.service.metric.MetricService;
 
 import org.apache.thrift.protocol.TProtocol;
@@ -45,7 +46,7 @@ public class InternalServiceThriftHandler implements TServerEventHandler {
   @Override
   public ServerContext createContext(TProtocol tProtocol, TProtocol tProtocol1) {
     thriftConnectionNumber.incrementAndGet();
-    return null;
+    return NoopServerContext.INSTANCE;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/MPPDataExchangeServiceThriftHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/MPPDataExchangeServiceThriftHandler.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.execution.exchange;
 
+import org.apache.iotdb.commons.service.NoopServerContext;
 import org.apache.iotdb.commons.service.metric.MetricService;
 
 import org.apache.thrift.protocol.TProtocol;
@@ -44,7 +45,7 @@ public class MPPDataExchangeServiceThriftHandler implements TServerEventHandler 
   @Override
   public ServerContext createContext(TProtocol input, TProtocol output) {
     thriftConnectionNumber.incrementAndGet();
-    return null;
+    return NoopServerContext.INSTANCE;
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/NoopServerContext.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/NoopServerContext.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.service;
+
+import org.apache.thrift.server.ServerContext;
+
+/**
+ * Shared {@link ServerContext} implementation for Thrift handlers that do not need per-connection
+ * state.
+ *
+ * <p>Thrift 0.23 server implementations expect {@code createContext} to return a non-null context,
+ * even when the event handler only uses connection lifecycle callbacks. This no-op implementation
+ * keeps those handlers explicit without adding a custom context object for each connection.
+ */
+public final class NoopServerContext implements ServerContext {
+
+  /** Singleton instance reused by handlers that do not attach state to the connection. */
+  public static final NoopServerContext INSTANCE = new NoopServerContext();
+
+  private NoopServerContext() {}
+
+  @Override
+  public <T> T unwrap(Class<T> iface) {
+    return iface.isInstance(this) ? iface.cast(this) : null;
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) {
+    return iface.isInstance(this);
+  }
+}

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/mock/MockInternalRPCService.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/mock/MockInternalRPCService.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.commons.client.mock;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.exception.runtime.RPCServiceException;
+import org.apache.iotdb.commons.service.NoopServerContext;
 import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
@@ -30,7 +31,9 @@ import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 
 import org.apache.thrift.server.TServerEventHandler;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MockInternalRPCService extends ThriftService implements MockInternalRPCServiceMBean {
 
@@ -60,6 +63,8 @@ public class MockInternalRPCService extends ThriftService implements MockInterna
   @Override
   public void initThriftServiceThread() throws IllegalAccessException {
     try {
+      TServerEventHandler serverEventHandler = mock(TServerEventHandler.class);
+      when(serverEventHandler.createContext(any(), any())).thenReturn(NoopServerContext.INSTANCE);
       thriftServiceThread =
           new ThriftServiceThread(
               processor,
@@ -69,7 +74,7 @@ public class MockInternalRPCService extends ThriftService implements MockInterna
               getBindPort(),
               65535,
               60,
-              mock(TServerEventHandler.class),
+              serverEventHandler,
               false,
               DeepCopyRpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/service/NoopServerContextTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/service/NoopServerContextTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.service;
+
+import org.apache.thrift.server.ServerContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NoopServerContextTest {
+
+  @Test
+  public void testUnwrap() {
+    Assert.assertSame(
+        NoopServerContext.INSTANCE, NoopServerContext.INSTANCE.unwrap(NoopServerContext.class));
+    Assert.assertSame(
+        NoopServerContext.INSTANCE, NoopServerContext.INSTANCE.unwrap(ServerContext.class));
+    Assert.assertNull(NoopServerContext.INSTANCE.unwrap(String.class));
+  }
+
+  @Test
+  public void testIsWrapperFor() {
+    Assert.assertTrue(NoopServerContext.INSTANCE.isWrapperFor(NoopServerContext.class));
+    Assert.assertTrue(NoopServerContext.INSTANCE.isWrapperFor(ServerContext.class));
+    Assert.assertFalse(NoopServerContext.INSTANCE.isWrapperFor(String.class));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
       This is the version of the thrift binary, that we release separately from here:
       https://github.com/apache/iotdb-bin-resources/tree/main/iotdb-tools-thrift
     -->
-        <iotdb-tools-thrift.version>0.14.1.0</iotdb-tools-thrift.version>
+        <iotdb-tools-thrift.version>0.23.0.0</iotdb-tools-thrift.version>
         <jackson.version>2.16.2</jackson.version>
         <!-- This is the last version to support the javax namespace -->
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
@@ -162,13 +162,7 @@
         <swagger.version>1.6.14</swagger.version>
         <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
         <thrift.exec.absolute.path/>
-        <!--
-      Thrift 0.17.0 was the last version that could be used in Java 8 applications,
-      However Thrift 0.17.0 has an invalid entry in the META-INF/MANIFEST.mf file.
-      All versions between 0.17.0 and 0.14.1 have know vulnerabilities, so for now
-      we'll stay at 0.14.1.
-    -->
-        <thrift.version>0.14.1</thrift.version>
+        <thrift.version>0.23.0</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
         <tsfile.version>1.1.4-260130-SNAPSHOT</tsfile.version>
@@ -197,15 +191,38 @@
                 <artifactId>libthrift</artifactId>
                 <version>${thrift.version}</version>
                 <exclusions>
-                    <!-- Seemed suspicious to have this dependency in -->
+                    <!-- We don't use thrift HTTP client or servlet transports. -->
                     <exclusion>
-                        <groupId>org.apache.tomcat.embed</groupId>
-                        <artifactId>tomcat-embed-core</artifactId>
+                        <groupId>org.apache.httpcomponents.client5</groupId>
+                        <artifactId>httpclient5</artifactId>
                     </exclusion>
-                    <!-- We don't want the old javax packages -->
                     <exclusion>
-                        <groupId>javax.annotation</groupId>
-                        <artifactId>javax.annotation-api</artifactId>
+                        <groupId>org.apache.httpcomponents.core5</groupId>
+                        <artifactId>httpcore5</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents.core5</groupId>
+                        <artifactId>httpcore5-h2</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.servlet</groupId>
+                        <artifactId>jakarta.servlet-api</artifactId>
+                    </exclusion>
+                    <!--
+                      Thrift generated Java sources suppress @Generated annotations.
+                      IoTDB does not use libthrift APIs that require Jakarta annotations.
+                    -->
+                    <exclusion>
+                        <groupId>jakarta.annotation</groupId>
+                        <artifactId>jakarta.annotation-api</artifactId>
+                    </exclusion>
+                    <!--
+                      commons-lang3 is only used by Thrift's partial deserialization runtime.
+                      IoTDB does not use org.apache.thrift.partial APIs.
+                    -->
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
## Description

Backport the Thrift 0.23.0 upgrade from master (#17945) to `dev/1.3`.

- bump the Thrift runtime and bundled compiler to 0.23.0
- update the binary license inventory and JDBC feature bundle
- exclude unused HTTP, Jakarta, and partial-deserialization transitive dependencies
- return a reusable non-null `ServerContext` from Thrift server event handlers for 0.23 compatibility
- update the test RPC handler and add coverage for the no-op context
- declare the integration-test HTTP client dependencies explicitly after the Thrift transitive dependency change

This backport intentionally does not change the C++ client or C++ workflows.

## Impact

Java clients and server components on `dev/1.3` now build and run against Thrift 0.23.0 while preserving the Java 8 and `javax` dependency baseline.

## Validation

- `./mvnw spotless:apply -pl iotdb-client/service-rpc,iotdb-core/node-commons,iotdb-core/confignode,iotdb-core/consensus,iotdb-core/datanode`
- `./mvnw spotless:apply -pl integration-test -P with-integration-tests`
- `./mvnw test-compile -DskipTests -pl integration-test -am -P with-integration-tests` (31/31 reactor modules succeeded; all 476 integration-test sources compiled)
- `./mvnw test-compile -DskipTests` (all Thrift generation and affected Java modules compiled successfully; the reactor later stopped in `distribution` because `test-compile` does not produce its required local server/CLI/ConfigNode ZIP artifacts)
- `./mvnw -pl iotdb-core/node-commons -am -Dtest=NoopServerContextTest -Dsurefire.failIfNoSpecifiedTests=false test`
- verified `iotdb-thrift-commons` resolves only `org.apache.thrift:libthrift:0.23.0` from the inspected Thrift dependency set