### PR TITLE
fix: reuse pre-computed ArrayList instance size in AlignedTVList ram cost

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.i18n.DataNodeMiscMessages;
@@ -1540,11 +1541,12 @@ public abstract class AlignedTVList extends TVList {
   }
 
   static long listRamCostWithReferences(List<?> list) {
-    return RamUsageEstimator.shallowSizeOf(list) + RamUsageEstimator.sizeOfObjectArray(list.size());
+    return MemoryEstimationHelper.ARRAY_LIST_INSTANCE_SIZE
+        + RamUsageEstimator.sizeOfObjectArray(list.size());
   }
 
   static long listRamCostWithoutReferences(List<?> list) {
-    return RamUsageEstimator.shallowSizeOf(list)
+    return MemoryEstimationHelper.ARRAY_LIST_INSTANCE_SIZE
         + (list.isEmpty() ? 0 : RamUsageEstimator.sizeOfObjectArray(0));
   }
 


### PR DESCRIPTION
## Motivation

On the write path, `AlignedTVList.getRamSize()` is called twice per `insertTablet` (pre-write snapshot + post-write reconciliation). `calculateContainerRamCost()` calls `RamUsageEstimator.shallowSizeOf(list)` for every `ArrayList` in the N-wide containers, which performs reflective layout computation on each call.

An async-profiler flame graph confirmed that within `DataRegion.insertTablet`, the `getRamSize` chain accounts for a significant share of CPU time, and the self time is almost entirely in `RamUsageEstimator.shallowSizeOfInstance`.

## Change

Replace the per-call `RamUsageEstimator.shallowSizeOf(list)` with the pre-computed constant `MemoryEstimationHelper.ARRAY_LIST_INSTANCE_SIZE` in `listRamCostWithReferences` and `listRamCostWithoutReferences`.

All lists passed to these helpers (`dataTypes`, `timestamps`, `indices`, `values`, `bitMaps` and their inner lists) are `ArrayList` instances, so the constant is exactly equal to `shallowSizeOf` for them and the accounting result is unchanged.