### PR TITLE
fix: retry SyncStatus batch memory reservation

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
@@ -49,10 +49,15 @@ public class SyncStatus {
    * @throws InterruptedException
    */
   public synchronized void addNextBatch(Batch batch) throws InterruptedException {
-    while ((pendingBatches.size() >= config.getReplication().getMaxPendingBatchesNum()
-            || !iotConsensusMemoryManager.reserve(batch))
-        && !Thread.interrupted()) {
-      wait();
+    while (true) {
+      while (pendingBatches.size() >= config.getReplication().getMaxPendingBatchesNum()) {
+        wait();
+      }
+      if (iotConsensusMemoryManager.reserve(batch)) {
+        break;
+      }
+      // Memory may be freed by another SyncStatus, which cannot notify this monitor.
+      wait(Math.max(1, config.getReplication().getBasicRetryWaitTimeMs()));
     }
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatusTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatusTest.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.consensus.iot.logdispatcher;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.commons.memory.AtomicLongMemoryBlock;
+import org.apache.iotdb.commons.memory.IMemoryBlock;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.config.IoTConsensusConfig;
 import org.apache.iotdb.consensus.iot.thrift.TLogEntry;
@@ -36,7 +38,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SyncStatusTest {
 
@@ -241,5 +250,60 @@ public class SyncStatusTest {
         config.getReplication().getMaxPendingBatchesNum(), controller.getCurrentIndex());
     Assert.assertEquals(
         config.getReplication().getMaxPendingBatchesNum() + 1, status.getNextSendingIndex());
+  }
+
+  @Test
+  public void testFirstBatchRetriesMemoryReservation()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    IndexController controller =
+        new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
+    IoTConsensusConfig retryConfig =
+        IoTConsensusConfig.newBuilder()
+            .setReplication(
+                IoTConsensusConfig.Replication.newBuilder().setBasicRetryWaitTimeMs(10).build())
+            .build();
+    SyncStatus status = new SyncStatus(controller, retryConfig);
+    TLogEntry logEntry = new TLogEntry().setSearchIndex(1).setMemorySize(1);
+    Batch batch = new Batch(retryConfig);
+    batch.addTLogEntry(logEntry);
+    batch.buildIndex();
+
+    IoTConsensusMemoryManager memoryManager = IoTConsensusMemoryManager.getInstance();
+    IMemoryBlock previousMemoryBlock = memoryManager.getMemoryBlock();
+    CountDownLatch firstAllocationFailed = new CountDownLatch(1);
+    AtomicBoolean rejectAllocation = new AtomicBoolean(true);
+    IMemoryBlock memoryBlock =
+        new AtomicLongMemoryBlock("SyncStatusTest", null, batch.getMemorySize()) {
+          @Override
+          public boolean allocate(long sizeInByte) {
+            if (rejectAllocation.compareAndSet(true, false)) {
+              firstAllocationFailed.countDown();
+              return false;
+            }
+            return super.allocate(sizeInByte);
+          }
+        };
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    memoryManager.setMemoryBlock(memoryBlock);
+    try {
+      Future<?> future =
+          executor.submit(
+              () -> {
+                status.addNextBatch(batch);
+                return null;
+              });
+
+      Assert.assertTrue(firstAllocationFailed.await(5, TimeUnit.SECONDS));
+      future.get(5, TimeUnit.SECONDS);
+
+      Assert.assertEquals(1, status.getPendingBatches().size());
+      status.removeBatch(batch);
+      Assert.assertEquals(0, status.getPendingBatches().size());
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+      status.free();
+      memoryManager.setMemoryBlock(previousMemoryBlock);
+    }
   }
 }


### PR DESCRIPTION
## Description

### Fix SyncStatus memory reservation retry

When the first batch fails to reserve consensus memory, its `SyncStatus` has no pending batch whose completion can call `notifyAll()`. The dispatcher can therefore wait indefinitely even after memory becomes available elsewhere.

This change separates pending-batch backpressure from memory reservation. A full pending queue still waits for `removeBatch()` notification, while a failed memory reservation waits for at least 1 ms using the configured basic retry interval and then retries. It also preserves normal `InterruptedException` semantics instead of clearing the interrupt and potentially enqueueing an unreserved batch.

### Regression coverage

Adds a unit test with a memory block that rejects the first allocation and accepts the second, verifying that the first batch progresses without an external notification and that reserved memory is released afterward.

Validation:

- `mvn test -pl iotdb-core/consensus -Dtest=SyncStatusTest`
- `mvn test -pl iotdb-core/consensus -Dtest=SyncStatusTest -P with-zh-locale`
- Spotless and Checkstyle passed in both runs

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent write
- [x] added comments explaining the why and the intent of the code wherever it would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.

<hr>

##### Key changed/added classes

- `SyncStatus`: retry failed batch memory reservations without relying on another batch to notify the monitor.
- `SyncStatusTest`: cover first-batch allocation failure and recovery.