### PR TITLE
Avoid duplicate DataNode memory configuration initialization

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -141,7 +141,7 @@ public class IoTDBDescriptor {
   }
 
   protected IoTDBDescriptor() {
-    loadProps();
+    boolean hasLoadedProperties = loadProps();
     ServiceLoader<IPropertiesLoader> propertiesLoaderServiceLoader =
         ServiceLoader.load(IPropertiesLoader.class);
     boolean hasProperties = false;
@@ -167,8 +167,8 @@ public class IoTDBDescriptor {
           .getConfig()
           .setCustomizedProperties(loader.getCustomizedProperties());
     }
-    // if there are no properties, we need to init memory config
-    if (!hasProperties) {
+    // If no configuration source initialized the memory config, initialize it with defaults.
+    if (!hasLoadedProperties && !hasProperties) {
       memoryConfig.init(new TrimProperties());
     }
   }
@@ -227,7 +227,7 @@ public class IoTDBDescriptor {
 
   /** load a property file and set TsfileDBConfig variables. */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
-  private void loadProps() {
+  private boolean loadProps() {
     TrimProperties commonProperties = new TrimProperties();
     // if new properties file exist, skip old properties files
     URL url = getPropsUrl(CommonConfig.SYSTEM_CONFIG_NAME);
@@ -256,11 +256,13 @@ public class IoTDBDescriptor {
             .getMetricConfig()
             .updateRpcInstance(NodeType.DATANODE, SchemaConstant.SYSTEM_DATABASE);
       }
+      return true;
     } else {
       LOGGER.warn(
           DataNodeMiscMessages
               .MISC_LOG_COULDN_T_LOAD_THE_CONFIGURATION_FROM_ANY_OF_THE_KNOWN_SOURCES_EE3ED103,
           CommonConfig.SYSTEM_CONFIG_NAME);
+      return false;
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorDefaultMemoryConfigTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorDefaultMemoryConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf;
+
+import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.memory.MemoryConfig;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IoTDBDescriptorDefaultMemoryConfigTest {
+
+  @Test
+  public void testNoConfigurationSourceInitializesDefaultRpcBufferMemory() {
+    String originalConf = System.getProperty(IoTDBConstant.IOTDB_CONF);
+    // An unsupported classpath URL makes getPropsUrl return null without opening a file.
+    System.setProperty(IoTDBConstant.IOTDB_CONF, "classpath:/missing-iotdb-system.properties");
+
+    try {
+      // The descriptor and MemoryConfig statics are isolated by surefire's per-class fork.
+      IoTDBDescriptor descriptor = new IoTDBDescriptor();
+      descriptor.getMemoryConfig().activateAutoResizingBufferMemoryControl();
+
+      assertEquals(
+          Runtime.getRuntime().maxMemory() / 20,
+          MemoryConfig.getInstance().getAutoResizingBufferMemoryTotalSizeInBytes());
+    } finally {
+      if (originalConf == null) {
+        System.clearProperty(IoTDBConstant.IOTDB_CONF);
+      } else {
+        System.setProperty(IoTDBConstant.IOTDB_CONF, originalConf);
+      }
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorSystemPropertiesTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorSystemPropertiesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.memory.MemoryConfig;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+
+public class IoTDBDescriptorSystemPropertiesTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testSystemPropertiesInitializeConfiguredRpcBufferMemory() throws Exception {
+    String originalConf = System.getProperty(IoTDBConstant.IOTDB_CONF);
+    File confDir = temporaryFolder.newFolder();
+    Files.writeString(
+        confDir.toPath().resolve(CommonConfig.SYSTEM_CONFIG_NAME),
+        "datanode_memory_proportion=1:1:1:1:1:5\n",
+        StandardCharsets.UTF_8);
+    System.setProperty(IoTDBConstant.IOTDB_CONF, confDir.getAbsolutePath());
+
+    try {
+      // The descriptor and MemoryConfig statics are isolated by surefire's per-class fork.
+      IoTDBDescriptor descriptor = new IoTDBDescriptor();
+      descriptor.getMemoryConfig().activateAutoResizingBufferMemoryControl();
+
+      assertEquals(
+          Runtime.getRuntime().maxMemory() / 4,
+          MemoryConfig.getInstance().getAutoResizingBufferMemoryTotalSizeInBytes());
+    } finally {
+      if (originalConf == null) {
+        System.clearProperty(IoTDBConstant.IOTDB_CONF);
+      } else {
+        System.setProperty(IoTDBConstant.IOTDB_CONF, originalConf);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

### Problem

IoTDBDescriptor initialized the DataNode memory configuration while loading iotdb-system.properties, then initialized it again with default properties whenever no external properties loader was present. The second initialization could discard configuration-derived memory settings.

### Changes

- Make loadProps report whether the system configuration source was loaded.
- Initialize memoryConfig with defaults only when neither the system configuration nor an external properties loader initialized it.

### Validation

- mvn test -pl iotdb-core/datanode '-Dtest=IoTDBDescriptorTest,DataNodeMemoryConfigTest' -DfailIfNoTests=false
- 11 tests passed; Checkstyle and Spotless passed.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the why and the intent of the code wherever it would not be obvious for an unfamiliar reader.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- org.apache.iotdb.db.conf.IoTDBDescriptor