### PR TITLE
[Pipe] Support pooled TsFile parsing

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
@@ -177,6 +177,38 @@ public class PipeEventCollector implements EventCollector {
             && !sourceEvent.shouldParseTime());
   }
 
+  public boolean shouldParseTsFileEvent(final PipeTsFileInsertionEvent sourceEvent) {
+    return sourceEvent.shouldParse4Privilege()
+        || !skipParsing && (forceTabletFormat || !canSkipParsing4TsFileEvent(sourceEvent));
+  }
+
+  public void prepareTsFileEventForParallelParsing(final PipeTsFileInsertionEvent sourceEvent) {
+    if (sourceEvent.isProgressReportManagedByTsFileParser()
+        || !sourceEvent.shouldReportGeneratedEventsOnCommit()) {
+      return;
+    }
+    if (sourceEvent.getCommitId() <= EnrichedEvent.NO_COMMIT_ID) {
+      PipeEventCommitManager.getInstance()
+          .enrichWithCommitterKeyAndCommitId(sourceEvent, creationTime, regionId);
+    }
+    if (sourceEvent.getCommitId() > EnrichedEvent.NO_COMMIT_ID) {
+      sourceEvent.markProgressReportManagedByTsFileParser();
+    }
+  }
+
+  public PipeEventCollector forkForTsFileParser() {
+    final PipeEventCollector collector =
+        new PipeEventCollector(
+            pendingQueue,
+            creationTime,
+            regionId,
+            forceTabletFormat,
+            skipParsing,
+            isUsedForConsensusPipe);
+    collector.setProcessorExecutionGuard(processorExecutionGuard);
+    return collector;
+  }
+
   private void collectParsedRawTableEvent(final PipeRawTabletInsertionEvent parsedEvent) {
     if (!parsedEvent.hasNoNeedParsingAndIsEmpty()) {
       hasNoGeneratedEvent = false;
@@ -252,9 +284,20 @@ public class PipeEventCollector implements EventCollector {
         return;
       }
 
-      // Assign a commit id for this event in order to report progress in order.
-      PipeEventCommitManager.getInstance()
-          .enrichWithCommitterKeyAndCommitId(enrichedEvent, creationTime, regionId);
+      final PipeTsFileInsertionEvent progressReportSourceTsFile =
+          event instanceof PipeRawTabletInsertionEvent
+              ? ((PipeRawTabletInsertionEvent) event).getProgressReportSourceTsFile()
+              : null;
+      if (progressReportSourceTsFile == null) {
+        // Assign a commit id for this event in order to report progress in order.
+        PipeEventCommitManager.getInstance()
+            .enrichWithCommitterKeyAndCommitId(enrichedEvent, creationTime, regionId);
+      } else {
+        // The source TsFile owns the ordered commit id. Parsed tablets only retain its committer
+        // key so downstream queues can still identify the pipe session and region.
+        enrichedEvent.setCommitterKeyAndCommitId(
+            progressReportSourceTsFile.getCommitterKey(), EnrichedEvent.NO_COMMIT_ID);
+      }
 
       // Assign a rebootTime for iotConsensusV2
       enrichedEvent.setRebootTimes(PipeDataNodeAgent.runtime().getRebootTimes());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
@@ -21,8 +21,10 @@ package org.apache.iotdb.db.pipe.agent.task.connection;
 
 import org.apache.iotdb.commons.audit.UserEntity;
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.pipe.agent.task.connection.BlockingPendingQueue.PendingEventMemoryReservation;
 import org.apache.iotdb.commons.pipe.agent.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.commons.pipe.agent.task.progress.PipeEventCommitManager;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.IoTDBTreePatternOperations;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.event.ProgressReportEvent;
@@ -65,6 +67,7 @@ public class PipeEventCollector implements EventCollector {
   private final boolean skipParsing;
 
   private final boolean isUsedForConsensusPipe;
+  private final boolean isTsFileParserCollector;
   private PipeProcessorSubtaskExecutionGuard processorExecutionGuard =
       PipeProcessorSubtaskExecutionGuard.disabled();
 
@@ -79,12 +82,31 @@ public class PipeEventCollector implements EventCollector {
       final boolean forceTabletFormat,
       final boolean skipParsing,
       final boolean isUsedInConsensusPipe) {
+    this(
+        pendingQueue,
+        creationTime,
+        regionId,
+        forceTabletFormat,
+        skipParsing,
+        isUsedInConsensusPipe,
+        false);
+  }
+
+  private PipeEventCollector(
+      final UnboundedBlockingPendingQueue<Event> pendingQueue,
+      final long creationTime,
+      final int regionId,
+      final boolean forceTabletFormat,
+      final boolean skipParsing,
+      final boolean isUsedInConsensusPipe,
+      final boolean isTsFileParserCollector) {
     this.pendingQueue = pendingQueue;
     this.creationTime = creationTime;
     this.regionId = regionId;
     this.forceTabletFormat = forceTabletFormat;
     this.skipParsing = skipParsing;
     this.isUsedForConsensusPipe = isUsedInConsensusPipe;
+    this.isTsFileParserCollector = isTsFileParserCollector;
   }
 
   public void setProcessorExecutionGuard(
@@ -137,7 +159,7 @@ public class PipeEventCollector implements EventCollector {
     if (sourceEvent.shouldParseTimeOrPattern()) {
       collectParsedRawTableEvent(sourceEvent.parseEventWithPatternOrTime());
     } else {
-      collectEvent(sourceEvent);
+      collectEvent(sourceEvent, isTsFileParserCollector);
     }
   }
 
@@ -204,7 +226,8 @@ public class PipeEventCollector implements EventCollector {
             regionId,
             forceTabletFormat,
             skipParsing,
-            isUsedForConsensusPipe);
+            isUsedForConsensusPipe,
+            true);
     collector.setProcessorExecutionGuard(processorExecutionGuard);
     return collector;
   }
@@ -212,7 +235,7 @@ public class PipeEventCollector implements EventCollector {
   private void collectParsedRawTableEvent(final PipeRawTabletInsertionEvent parsedEvent) {
     if (!parsedEvent.hasNoNeedParsingAndIsEmpty()) {
       hasNoGeneratedEvent = false;
-      collectEvent(parsedEvent);
+      collectEvent(parsedEvent, isTsFileParserCollector);
     }
   }
 
@@ -275,49 +298,100 @@ public class PipeEventCollector implements EventCollector {
   }
 
   private void collectEvent(final Event event) {
-    if (event instanceof EnrichedEvent) {
-      final EnrichedEvent enrichedEvent = (EnrichedEvent) event;
-      if (!enrichedEvent.increaseReferenceCount(PipeEventCollector.class.getName())) {
-        LOGGER.warn(
-            DataNodePipeMessages.PIPEEVENTCOLLECTOR_THE_EVENT_IS_ALREADY_RELEASED_SKIPPING, event);
-        isFailedToIncreaseReferenceCount = true;
-        return;
-      }
+    collectEvent(event, false);
+  }
 
-      final PipeTsFileInsertionEvent progressReportSourceTsFile =
-          event instanceof PipeRawTabletInsertionEvent
-              ? ((PipeRawTabletInsertionEvent) event).getProgressReportSourceTsFile()
-              : null;
-      if (progressReportSourceTsFile == null) {
-        // Assign a commit id for this event in order to report progress in order.
-        PipeEventCommitManager.getInstance()
-            .enrichWithCommitterKeyAndCommitId(enrichedEvent, creationTime, regionId);
-      } else {
-        // The source TsFile owns the ordered commit id. Parsed tablets only retain its committer
-        // key so downstream queues can still identify the pipe session and region.
-        enrichedEvent.setCommitterKeyAndCommitId(
-            progressReportSourceTsFile.getCommitterKey(), EnrichedEvent.NO_COMMIT_ID);
-      }
-
-      // Assign a rebootTime for iotConsensusV2
-      enrichedEvent.setRebootTimes(PipeDataNodeAgent.runtime().getRebootTimes());
-
-      if (enrichedEvent.getPipeName() != null
-          && (pendingQueue.isEventFromDroppedPipe(enrichedEvent)
-              || (enrichedEvent.getCommitterKey() == null
-                  && pendingQueue.isPipeDropped(
-                      enrichedEvent.getPipeName(), creationTime, regionId)))) {
-        enrichedEvent.clearReferenceCount(PipeEventCollector.class.getName());
-        return;
+  private void collectEvent(final Event event, final boolean useParserQueueMemoryBackpressure) {
+    PendingEventMemoryReservation memoryReservation = null;
+    long tabletSizeInBytes = 0;
+    if (useParserQueueMemoryBackpressure && event instanceof PipeRawTabletInsertionEvent) {
+      tabletSizeInBytes = ((PipeRawTabletInsertionEvent) event).getTabletSizeInBytes();
+      memoryReservation =
+          pendingQueue.waitForMemoryReservation(
+              tabletSizeInBytes,
+              Math.max(1, PipeConfig.getInstance().getTsFileParserMemory()),
+              processorExecutionGuard::isCurrentInvocationValid);
+      if (memoryReservation == null) {
+        processorExecutionGuard.check();
+        throw new PipeException("Interrupted while waiting for parser output queue memory.");
       }
     }
 
-    if (event instanceof PipeHeartbeatEvent) {
-      ((PipeHeartbeatEvent) event).recordConnectorQueueSize(pendingQueue);
-    }
+    boolean isReferenceIncreased = false;
+    boolean isOffered = false;
+    try {
+      if (event instanceof EnrichedEvent) {
+        final EnrichedEvent enrichedEvent = (EnrichedEvent) event;
+        final boolean increased =
+            useParserQueueMemoryBackpressure && event instanceof PipeRawTabletInsertionEvent
+                ? ((PipeRawTabletInsertionEvent) event)
+                    .increaseReferenceCountWithReservedMemory(
+                        PipeEventCollector.class.getName(),
+                        Math.max(
+                            tabletSizeInBytes > Long.MAX_VALUE / 2
+                                ? Long.MAX_VALUE
+                                : tabletSizeInBytes * 2,
+                            PipeConfig.getInstance().getPipeDataStructureTabletSizeInBytes()))
+                : enrichedEvent.increaseReferenceCount(PipeEventCollector.class.getName());
+        if (!increased) {
+          LOGGER.warn(
+              DataNodePipeMessages.PIPEEVENTCOLLECTOR_THE_EVENT_IS_ALREADY_RELEASED_SKIPPING,
+              event);
+          isFailedToIncreaseReferenceCount = true;
+          return;
+        }
+        isReferenceIncreased = true;
 
-    if (pendingQueue.offer(event)) {
-      collectInvocationCount.incrementAndGet();
+        final PipeTsFileInsertionEvent progressReportSourceTsFile =
+            event instanceof PipeRawTabletInsertionEvent
+                ? ((PipeRawTabletInsertionEvent) event).getProgressReportSourceTsFile()
+                : null;
+        if (progressReportSourceTsFile == null) {
+          // Assign a commit id for this event in order to report progress in order.
+          PipeEventCommitManager.getInstance()
+              .enrichWithCommitterKeyAndCommitId(enrichedEvent, creationTime, regionId);
+        } else {
+          // The source TsFile owns the ordered commit id. Parsed tablets only retain its committer
+          // key so downstream queues can still identify the pipe session and region.
+          enrichedEvent.setCommitterKeyAndCommitId(
+              progressReportSourceTsFile.getCommitterKey(), EnrichedEvent.NO_COMMIT_ID);
+        }
+
+        // Assign a rebootTime for iotConsensusV2
+        enrichedEvent.setRebootTimes(PipeDataNodeAgent.runtime().getRebootTimes());
+
+        if (enrichedEvent.getPipeName() != null
+            && (pendingQueue.isEventFromDroppedPipe(enrichedEvent)
+                || (enrichedEvent.getCommitterKey() == null
+                    && pendingQueue.isPipeDropped(
+                        enrichedEvent.getPipeName(), creationTime, regionId)))) {
+          enrichedEvent.clearReferenceCount(PipeEventCollector.class.getName());
+          return;
+        }
+      }
+
+      if (event instanceof PipeHeartbeatEvent) {
+        ((PipeHeartbeatEvent) event).recordConnectorQueueSize(pendingQueue);
+      }
+
+      isOffered =
+          memoryReservation == null
+              ? pendingQueue.offer(event)
+              : pendingQueue.offer(event, memoryReservation);
+      if (isOffered) {
+        memoryReservation = null;
+        collectInvocationCount.incrementAndGet();
+      }
+    } finally {
+      if (memoryReservation != null) {
+        memoryReservation.close();
+      }
+      if (!isOffered
+          && isReferenceIncreased
+          && event instanceof EnrichedEvent
+          && !((EnrichedEvent) event).isReleased()) {
+        ((EnrichedEvent) event).decreaseReferenceCount(PipeEventCollector.class.getName(), false);
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/stage/PipeTaskProcessorStage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/stage/PipeTaskProcessorStage.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.pipe.agent.task.stage;
 import org.apache.iotdb.commons.audit.UserEntity;
 import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.pipe.agent.plugin.builtin.BuiltinPipePlugin;
+import org.apache.iotdb.commons.pipe.agent.plugin.builtin.processor.donothing.DoNothingProcessor;
 import org.apache.iotdb.commons.pipe.agent.task.connection.EventSupplier;
 import org.apache.iotdb.commons.pipe.agent.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeRuntimeMeta;
@@ -45,6 +46,9 @@ import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.exception.PipeException;
+
+import static org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant.PROCESSOR_TSFILE_PARSER_PARALLELISM_DEFAULT_VALUE;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant.PROCESSOR_TSFILE_PARSER_PARALLELISM_KEY;
 
 public class PipeTaskProcessorStage extends PipeTaskStage {
 
@@ -122,7 +126,12 @@ public class PipeTaskProcessorStage extends PipeTaskStage {
             regionId,
             pipeSourceInputEventSupplier,
             pipeProcessor,
-            pipeSinkOutputEventCollector);
+            pipeSinkOutputEventCollector,
+            pipeProcessor.getClass() == DoNothingProcessor.class
+                ? pipeProcessorParameters.getIntOrDefault(
+                    PROCESSOR_TSFILE_PARSER_PARALLELISM_KEY,
+                    PROCESSOR_TSFILE_PARSER_PARALLELISM_DEFAULT_VALUE)
+                : PROCESSOR_TSFILE_PARSER_PARALLELISM_DEFAULT_VALUE);
 
     this.executor = executor;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
@@ -19,15 +19,19 @@
 
 package org.apache.iotdb.db.pipe.agent.task.subtask.processor;
 
+import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
+import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeException;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeOutOfMemoryCriticalException;
+import org.apache.iotdb.commons.pipe.agent.plugin.builtin.processor.donothing.DoNothingProcessor;
 import org.apache.iotdb.commons.pipe.agent.task.connection.EventSupplier;
 import org.apache.iotdb.commons.pipe.agent.task.execution.PipeSubtaskScheduler;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.progress.PipeEventCommitManager;
 import org.apache.iotdb.commons.pipe.agent.task.subtask.PipeReportableSubtask;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
+import org.apache.iotdb.commons.pipe.event.ProgressReportEvent;
 import org.apache.iotdb.commons.pipe.resource.PipeResourceFailureType;
 import org.apache.iotdb.commons.pipe.resource.log.PipeLogger;
 import org.apache.iotdb.commons.utils.ErrorHandlingCommonUtils;
@@ -56,13 +60,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PipeProcessorSubtask extends PipeReportableSubtask {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PipeProcessorSubtask.class);
+
+  private static final ExecutorService TS_FILE_PARSER_EXECUTOR =
+      IoTDBThreadPoolFactory.newCachedThreadPool(
+          ThreadName.PIPE_TSFILE_PARSER_EXECUTOR_POOL.getName());
 
   private static final AtomicReference<PipeProcessorSubtaskWorkerManager> subtaskWorkerManager =
       new AtomicReference<>();
@@ -81,6 +95,12 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
   private final AtomicReference<EventProcessingContext> eventProcessingContext =
       new AtomicReference<>();
 
+  private final int tsFileParserParallelism;
+  private final Object tsFileParserTaskLock = new Object();
+  private final Deque<TsFileParserTask> inFlightTsFileParserTasks = new ArrayDeque<>();
+  private Event pendingEventAfterTsFileParserBarrier;
+  private volatile PipeTsFileInsertionEvent retryingFailedTsFileParserEvent;
+
   // This variable is used to distinguish between old and new subtasks before and after stuck
   // restart.
   private final long subtaskCreationTime;
@@ -93,6 +113,26 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
       final EventSupplier inputEventSupplier,
       final PipeProcessor pipeProcessor,
       final PipeEventCollector outputEventCollector) {
+    this(
+        taskID,
+        pipeName,
+        creationTime,
+        regionId,
+        inputEventSupplier,
+        pipeProcessor,
+        outputEventCollector,
+        1);
+  }
+
+  public PipeProcessorSubtask(
+      final String taskID,
+      final String pipeName,
+      final long creationTime,
+      final int regionId,
+      final EventSupplier inputEventSupplier,
+      final PipeProcessor pipeProcessor,
+      final PipeEventCollector outputEventCollector,
+      final int tsFileParserParallelism) {
     super(taskID, creationTime);
     this.pipeName = pipeName;
     this.pipeNameWithCreationTime = pipeName + "_" + creationTime;
@@ -101,6 +141,10 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     this.pipeProcessor = pipeProcessor;
     this.outputEventCollector = outputEventCollector;
     this.outputEventCollector.setProcessorExecutionGuard(executionGuard);
+    this.tsFileParserParallelism =
+        pipeProcessor.getClass() == DoNothingProcessor.class
+            ? Math.max(1, tsFileParserParallelism)
+            : 1;
     this.subtaskCreationTime = System.currentTimeMillis();
 
     // Only register dataRegions
@@ -149,12 +193,35 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     }
 
     executionGuard.check();
-    final Event event =
-        lastEvent != null
-            ? lastEvent
-            : UserDefinedEnrichedEvent.maybeOf(inputEventSupplier.supply());
-    // Record the last event for retry when exception occurs
-    setLastEvent(event);
+    // Preserve the event currently being retried. Other parser failures are reaped after this
+    // event has been resubmitted, otherwise a later failure could overwrite lastEvent.
+    final TsFileParserTaskResult failedResult =
+        lastEvent == null ? reapCompletedTsFileParserTasks() : null;
+    if (failedResult != null) {
+      if (!retainFailedTsFileParserEvent(failedResult.event)) {
+        return false;
+      }
+      if (ExceptionUtils.getRootCause(failedResult.exception)
+          instanceof PipeRuntimeOutOfMemoryCriticalException) {
+        recordResourceFailure(failedResult.event, PipeResourceFailureType.MEMORY_TIMEOUT);
+        PipeLogger.log(
+            LOGGER::info,
+            DataNodePipeMessages.TEMPORARILY_OUT_OF_MEMORY_IN_PIPE_EVENT_PROCESSING,
+            failedResult.exception.getMessage());
+        return false;
+      }
+      retryingFailedTsFileParserEvent = failedResult.event;
+      throw new PipeException(
+          String.format(
+              DataNodePipeMessages
+                  .PIPE_EXCEPTION_EXCEPTION_IN_PIPE_PROCESS_SUBTASK_S_LAST_EVENT_S_ROOT_CAUSE_95B49C24,
+              getDisplayTaskID(),
+              failedResult.event.coreReportMessage(),
+              ErrorHandlingCommonUtils.getRootCause(failedResult.exception).getMessage()),
+          failedResult.exception);
+    }
+
+    final Event event = getNextEvent();
 
     if (Objects.isNull(event)) {
       return false;
@@ -171,6 +238,26 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
       if (event instanceof EnrichedEvent) {
         ((EnrichedEvent) event).throwIfNoPrivilege();
       }
+
+      if (shouldParseTsFileEventInPool(event)) {
+        final PipeTsFileInsertionEvent tsFileInsertionEvent =
+            (PipeTsFileInsertionEvent) event;
+        if (!tsFileInsertionEvent.tryReserveTsFileParserMemory()) {
+          executionGuard.yieldIfParserNotAdmitted();
+        }
+
+        executionGuard.check();
+        outputEventCollector.prepareTsFileEventForParallelParsing(tsFileInsertionEvent);
+        submitTsFileParserTask(tsFileInsertionEvent);
+        setLastEvent(null);
+        return true;
+      }
+
+      if (event != retryingFailedTsFileParserEvent && deferEventUntilTsFileParserBarrier(event)) {
+        setLastEvent(null);
+        return false;
+      }
+
       // event can be supplied after the subtask is closed, so we need to check isClosed here
       if (!isClosed.get()) {
         if (event instanceof TabletInsertionEvent) {
@@ -195,31 +282,9 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
           }
           PipeProcessorMetrics.getInstance().markTabletEvent(taskID);
         } else if (event instanceof TsFileInsertionEvent) {
-          // We have to parse the privilege first, to avoid passing no-privilege data to processor
-          if (event instanceof PipeTsFileInsertionEvent
-              && ((PipeTsFileInsertionEvent) event).shouldParse4Privilege()) {
-            final PipeTsFileInsertionEvent tsFileInsertionEvent = (PipeTsFileInsertionEvent) event;
-            tsFileInsertionEvent.consumeTabletInsertionEventsWithRetry(
-                event1 -> {
-                  try {
-                    pipeProcessor.process(event1, outputEventCollector);
-                  } catch (PipeProcessorSubtaskYieldException e) {
-                    throw e;
-                  } catch (PipeRuntimeOutOfMemoryCriticalException e) {
-                    throw e;
-                  } catch (Exception e) {
-                    throw new PipeException(e.getMessage(), e);
-                  }
-                },
-                "PipeProcessorSubtask::executeOnce",
-                executionGuard);
-            tsFileInsertionEvent.close();
-            if (tsFileInsertionEvent.isGeneratedByHistoricalExtractor()) {
-              PipeTerminateEvent.markHistoricalTsFileSplit(
-                  tsFileInsertionEvent.getPipeName(),
-                  tsFileInsertionEvent.getCreationTime(),
-                  regionId);
-            }
+          if (event instanceof PipeTsFileInsertionEvent) {
+            processTsFileInsertionEvent(
+                (PipeTsFileInsertionEvent) event, outputEventCollector, executionGuard);
           } else {
             pipeProcessor.process((TsFileInsertionEvent) event, outputEventCollector);
           }
@@ -251,15 +316,25 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
               // 2. If the event is not collected (not passed to the connector), the reference count
               // of the event must be zero in the processor stage, at this time, the progress of the
               // event needs to be reported.
-              && outputEventCollector.hasNoGeneratedEvent()
+              && (outputEventCollector.hasNoGeneratedEvent()
+                  || event instanceof PipeTsFileInsertionEvent
+                      && ((PipeTsFileInsertionEvent) event)
+                          .isProgressReportManagedByTsFileParser())
               // If the event's reference count cannot be increased, it means that the event has
               // been released, and the progress of the event can not be reported.
               && !outputEventCollector.isFailedToIncreaseReferenceCount()
               // Events generated from consensusPipe's transferred data should never be reported.
               && !(pipeProcessor instanceof IoTConsensusV2Processor);
+      if (!shouldReport
+          && event instanceof PipeTsFileInsertionEvent
+          && ((PipeTsFileInsertionEvent) event).isProgressReportManagedByTsFileParser()) {
+        ((PipeTsFileInsertionEvent) event).abortProgressReportManagedByTsFileParser();
+        ((PipeTsFileInsertionEvent) event).skipReportOnCommit();
+      }
       if (shouldReport
           && event instanceof EnrichedEvent
-          && outputEventCollector.hasNoCollectInvocationAfterReset()) {
+          && outputEventCollector.hasNoCollectInvocationAfterReset()
+          && ((EnrichedEvent) event).getCommitId() <= EnrichedEvent.NO_COMMIT_ID) {
         // An event should be reported here when it is not passed to the connector stage, and it
         // does not generate any new events to be passed to the connector. In our system, before
         // reporting an event, we need to enrich a commitKey and commitId, which is done in the
@@ -270,7 +345,17 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
             .enrichWithCommitterKeyAndCommitId((EnrichedEvent) event, creationTime, regionId);
       }
       decreaseReferenceCountAndReleaseLastEvent(event, shouldReport);
+      if (event == retryingFailedTsFileParserEvent) {
+        retryingFailedTsFileParserEvent = null;
+      }
     } catch (final PipeProcessorSubtaskYieldException e) {
+      if (event instanceof PipeTsFileInsertionEvent) {
+        final PipeTsFileInsertionEvent tsFileInsertionEvent = (PipeTsFileInsertionEvent) event;
+        tsFileInsertionEvent.releaseTsFileParserMemoryIfReserved();
+        if (!executionGuard.isCurrentInvocationValid()) {
+          tsFileInsertionEvent.cancelTsFileParserMemoryReservationIfPending();
+        }
+      }
       isResumingFromYield.set(true);
       throw e;
     } catch (final PipeRuntimeOutOfMemoryCriticalException e) {
@@ -318,11 +403,387 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     return true;
   }
 
+  private Event getNextEvent() throws Exception {
+    if (lastEvent != null) {
+      return lastEvent;
+    }
+
+    synchronized (tsFileParserTaskLock) {
+      if (pendingEventAfterTsFileParserBarrier != null) {
+        if (!inFlightTsFileParserTasks.isEmpty()) {
+          return null;
+        }
+        final Event event = pendingEventAfterTsFileParserBarrier;
+        pendingEventAfterTsFileParserBarrier = null;
+        setLastEvent(event);
+        return event;
+      }
+
+      if (inFlightTsFileParserTasks.size() >= tsFileParserParallelism) {
+        return null;
+      }
+    }
+
+    final Event event = UserDefinedEnrichedEvent.maybeOf(inputEventSupplier.supply());
+    setLastEvent(event);
+    return event;
+  }
+
+  private synchronized boolean retainFailedTsFileParserEvent(
+      final PipeTsFileInsertionEvent event) {
+    if (isClosed.get()) {
+      if (!event.isReleased()) {
+        event.clearReferenceCount(PipeProcessorSubtask.class.getName());
+      }
+      return false;
+    }
+    lastEvent = event;
+    return true;
+  }
+
+  private boolean shouldParseTsFileEventInPool(final Event event) {
+    return tsFileParserParallelism > 1
+        && event instanceof PipeTsFileInsertionEvent
+        && event != retryingFailedTsFileParserEvent
+        && outputEventCollector.shouldParseTsFileEvent((PipeTsFileInsertionEvent) event);
+  }
+
+  private boolean deferEventUntilTsFileParserBarrier(final Event event) {
+    // These control events do not depend on parser completion. ProgressReportEvent is committed
+    // after preceding parser tasks, while PipeHeartbeatEvent does not need ordered commits.
+    if (event instanceof ProgressReportEvent || event instanceof PipeHeartbeatEvent) {
+      return false;
+    }
+
+    synchronized (tsFileParserTaskLock) {
+      if (isClosed.get() || inFlightTsFileParserTasks.isEmpty()) {
+        return false;
+      }
+      pendingEventAfterTsFileParserBarrier = event;
+      return true;
+    }
+  }
+
+  private void processTsFileInsertionEvent(
+      final PipeTsFileInsertionEvent event,
+      final PipeEventCollector eventCollector,
+      final PipeProcessorSubtaskExecutionGuard processorExecutionGuard)
+      throws Exception {
+    // Parse privileges before invoking the processor to avoid forwarding unauthorized data.
+    if (event.shouldParse4Privilege()) {
+      event.consumeTabletInsertionEventsWithRetry(
+          parsedEvent -> {
+            try {
+              pipeProcessor.process(parsedEvent, eventCollector);
+            } catch (final PipeProcessorSubtaskYieldException e) {
+              throw e;
+            } catch (final PipeRuntimeOutOfMemoryCriticalException e) {
+              throw e;
+            } catch (final Exception e) {
+              throw new PipeException(e.getMessage(), e);
+            }
+          },
+          "PipeProcessorSubtask::processTsFileInsertionEvent",
+          processorExecutionGuard);
+      event.close();
+      if (event.isGeneratedByHistoricalExtractor()) {
+        PipeTerminateEvent.markHistoricalTsFileSplit(
+            event.getPipeName(), event.getCreationTime(), regionId);
+      }
+      return;
+    }
+
+    pipeProcessor.process(event, eventCollector);
+  }
+
+  private void submitTsFileParserTask(final PipeTsFileInsertionEvent event) {
+    submitTsFileParserTask(new TsFileParserTask(event, outputEventCollector.forkForTsFileParser()));
+  }
+
+  private void submitTsFileParserTask(final TsFileParserTask task) {
+    synchronized (tsFileParserTaskLock) {
+      if (isClosed.get() || !task.prepareForSubmission()) {
+        task.cancel();
+        return;
+      }
+      inFlightTsFileParserTasks.addLast(task);
+    }
+
+    try {
+      task.setFuture(TS_FILE_PARSER_EXECUTOR.submit(task::execute));
+    } catch (final RuntimeException e) {
+      synchronized (tsFileParserTaskLock) {
+        inFlightTsFileParserTasks.remove(task);
+      }
+      task.cancel();
+      throw e;
+    }
+  }
+
+  private TsFileParserTaskResult reapCompletedTsFileParserTasks()
+      throws InterruptedException, ExecutionException {
+    while (true) {
+      final TsFileParserTask task;
+      synchronized (tsFileParserTaskLock) {
+        TsFileParserTask completedTask = null;
+        final Iterator<TsFileParserTask> iterator = inFlightTsFileParserTasks.iterator();
+        while (iterator.hasNext()) {
+          final TsFileParserTask candidate = iterator.next();
+          if (candidate.isDone()) {
+            completedTask = candidate;
+            iterator.remove();
+            break;
+          }
+        }
+        task = completedTask;
+        if (task == null) {
+          return null;
+        }
+      }
+
+      final TsFileParserTaskResult result;
+      try {
+        result = task.getResult();
+      } catch (final CancellationException e) {
+        if (isClosed.get()) {
+          return null;
+        }
+        throw e;
+      }
+
+      if (result.outcome == TsFileParserTaskOutcome.YIELDED) {
+        submitTsFileParserTask(task);
+        continue;
+      }
+      if (result.outcome == TsFileParserTaskOutcome.FAILURE) {
+        return result;
+      }
+    }
+  }
+
+  private void completeTsFileParserTask(
+      final PipeTsFileInsertionEvent event, final PipeEventCollector eventCollector) {
+    final boolean shouldReport =
+        !isClosed.get()
+            && (event.isProgressReportManagedByTsFileParser()
+                || eventCollector.hasNoGeneratedEvent())
+            && !eventCollector.isFailedToIncreaseReferenceCount()
+            && !(pipeProcessor instanceof IoTConsensusV2Processor);
+    if (!shouldReport && event.isProgressReportManagedByTsFileParser()) {
+      event.abortProgressReportManagedByTsFileParser();
+      event.skipReportOnCommit();
+    }
+    if (shouldReport
+        && eventCollector.hasNoCollectInvocationAfterReset()
+        && event.getCommitId() <= EnrichedEvent.NO_COMMIT_ID) {
+      PipeEventCommitManager.getInstance()
+          .enrichWithCommitterKeyAndCommitId(event, creationTime, regionId);
+    }
+
+    if (!event.isReleased()) {
+      event.decreaseReferenceCount(PipeProcessorSubtask.class.getName(), shouldReport);
+    }
+  }
+
+  private class TsFileParserTask {
+
+    private final PipeTsFileInsertionEvent event;
+    private final PipeEventCollector eventCollector;
+
+    private Future<TsFileParserTaskResult> future;
+    private boolean isStarted;
+    private boolean isFinished;
+    private boolean isCancelled;
+    private boolean ownsEvent = true;
+    private boolean isCollectorInitialized;
+
+    private TsFileParserTask(
+        final PipeTsFileInsertionEvent event, final PipeEventCollector eventCollector) {
+      this.event = event;
+      this.eventCollector = eventCollector;
+    }
+
+    private TsFileParserTaskResult execute() {
+      synchronized (this) {
+        if (isCancelled) {
+          return TsFileParserTaskResult.cancelled(event);
+        }
+        isStarted = true;
+      }
+
+      boolean hasEnteredExecutionGuard = false;
+      try {
+        executionGuard.enter();
+        hasEnteredExecutionGuard = true;
+        if (!isCollectorInitialized) {
+          eventCollector.resetFlags();
+          isCollectorInitialized = true;
+        }
+        processTsFileInsertionEvent(event, eventCollector, executionGuard);
+
+        synchronized (this) {
+          if (isCancelled || isClosed.get()) {
+            releaseOwnedEvent();
+            isFinished = true;
+            return TsFileParserTaskResult.cancelled(event);
+          }
+        }
+
+        PipeProcessorMetrics.getInstance().markTsFileEvent(taskID);
+        PipeDataNodeSinglePipeMetrics.getInstance()
+            .markTsFileCollectInvocationCount(
+                pipeNameWithCreationTime, eventCollector.getCollectInvocationCount());
+        completeTsFileParserTask(event, eventCollector);
+        synchronized (this) {
+          ownsEvent = false;
+          isFinished = true;
+        }
+        return TsFileParserTaskResult.success(event);
+      } catch (final PipeProcessorSubtaskYieldException e) {
+        event.releaseTsFileParserMemoryIfReserved();
+        if (!executionGuard.isCurrentInvocationValid()) {
+          event.cancelTsFileParserMemoryReservationIfPending();
+        }
+        synchronized (this) {
+          isFinished = true;
+          if (isCancelled || isClosed.get()) {
+            releaseOwnedEvent();
+            return TsFileParserTaskResult.cancelled(event);
+          }
+        }
+        return TsFileParserTaskResult.yielded(event);
+      } catch (final Exception e) {
+        event.releaseTsFileParserMemoryIfReserved();
+        synchronized (this) {
+          isFinished = true;
+          if (isCancelled || isClosed.get()) {
+            releaseOwnedEvent();
+            return TsFileParserTaskResult.cancelled(event);
+          }
+        }
+        return TsFileParserTaskResult.failure(event, e);
+      } finally {
+        if (hasEnteredExecutionGuard) {
+          executionGuard.exit();
+        }
+      }
+    }
+
+    private synchronized boolean prepareForSubmission() {
+      if (isCancelled) {
+        return false;
+      }
+      future = null;
+      isStarted = false;
+      isFinished = false;
+      return true;
+    }
+
+    private synchronized void setFuture(final Future<TsFileParserTaskResult> future) {
+      this.future = future;
+      if (isCancelled) {
+        future.cancel(true);
+      }
+    }
+
+    private synchronized boolean isDone() {
+      return future != null && future.isDone();
+    }
+
+    private TsFileParserTaskResult getResult() throws InterruptedException, ExecutionException {
+      final Future<TsFileParserTaskResult> currentFuture;
+      synchronized (this) {
+        currentFuture = future;
+      }
+      final TsFileParserTaskResult result = currentFuture.get();
+      if (result.outcome == TsFileParserTaskOutcome.FAILURE) {
+        synchronized (this) {
+          ownsEvent = false;
+        }
+      }
+      return result;
+    }
+
+    private void cancel() {
+      final Future<TsFileParserTaskResult> currentFuture;
+      synchronized (this) {
+        isCancelled = true;
+        if ((!isStarted || isFinished) && ownsEvent) {
+          releaseOwnedEvent();
+        }
+        currentFuture = future;
+      }
+      if (currentFuture != null) {
+        currentFuture.cancel(true);
+      }
+    }
+
+    private void releaseOwnedEvent() {
+      if (!ownsEvent) {
+        return;
+      }
+      event.close();
+      if (!event.isReleased()) {
+        event.clearReferenceCount(PipeProcessorSubtask.class.getName());
+      }
+      ownsEvent = false;
+    }
+  }
+
+  private enum TsFileParserTaskOutcome {
+    SUCCESS,
+    FAILURE,
+    YIELDED,
+    CANCELLED
+  }
+
+  private static class TsFileParserTaskResult {
+
+    private final PipeTsFileInsertionEvent event;
+    private final Exception exception;
+    private final TsFileParserTaskOutcome outcome;
+
+    private TsFileParserTaskResult(
+        final PipeTsFileInsertionEvent event,
+        final Exception exception,
+        final TsFileParserTaskOutcome outcome) {
+      this.event = event;
+      this.exception = exception;
+      this.outcome = outcome;
+    }
+
+    private static TsFileParserTaskResult success(final PipeTsFileInsertionEvent event) {
+      return new TsFileParserTaskResult(event, null, TsFileParserTaskOutcome.SUCCESS);
+    }
+
+    private static TsFileParserTaskResult failure(
+        final PipeTsFileInsertionEvent event, final Exception exception) {
+      return new TsFileParserTaskResult(event, exception, TsFileParserTaskOutcome.FAILURE);
+    }
+
+    private static TsFileParserTaskResult yielded(final PipeTsFileInsertionEvent event) {
+      return new TsFileParserTaskResult(event, null, TsFileParserTaskOutcome.YIELDED);
+    }
+
+    private static TsFileParserTaskResult cancelled(final PipeTsFileInsertionEvent event) {
+      return new TsFileParserTaskResult(event, null, TsFileParserTaskOutcome.CANCELLED);
+    }
+  }
+
   @Override
   public void submitSelf() {
     // this subtask won't be submitted to the executor directly
     // instead, it will be executed by the PipeProcessorSubtaskWorker
     // and the worker will be submitted to the executor
+  }
+
+  @Override
+  public void onSuccess(final Boolean hasAtLeastOneEventProcessed) {
+    if (retryingFailedTsFileParserEvent != null) {
+      submitSelf();
+      return;
+    }
+    super.onSuccess(hasAtLeastOneEventProcessed);
   }
 
   @Override
@@ -349,6 +810,17 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     PipeProcessorMetrics.getInstance().deregister(taskID);
     try {
       isClosed.set(true);
+      retryingFailedTsFileParserEvent = null;
+      final Event pendingEvent;
+      synchronized (tsFileParserTaskLock) {
+        inFlightTsFileParserTasks.forEach(TsFileParserTask::cancel);
+        inFlightTsFileParserTasks.clear();
+        pendingEvent = pendingEventAfterTsFileParserBarrier;
+        pendingEventAfterTsFileParserBarrier = null;
+      }
+      if (pendingEvent instanceof EnrichedEvent && !((EnrichedEvent) pendingEvent).isReleased()) {
+        ((EnrichedEvent) pendingEvent).clearReferenceCount(PipeProcessorSubtask.class.getName());
+      }
       pipeProcessor.close();
       // It is important to note that even if the subtask and its corresponding processor are
       // closed, the execution thread may still deliver events downstream.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
@@ -59,10 +59,10 @@ import org.apache.tsfile.external.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Objects;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -240,8 +240,7 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
       }
 
       if (shouldParseTsFileEventInPool(event)) {
-        final PipeTsFileInsertionEvent tsFileInsertionEvent =
-            (PipeTsFileInsertionEvent) event;
+        final PipeTsFileInsertionEvent tsFileInsertionEvent = (PipeTsFileInsertionEvent) event;
         if (!tsFileInsertionEvent.tryReserveTsFileParserMemory()) {
           executionGuard.yieldIfParserNotAdmitted();
         }
@@ -318,8 +317,7 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
               // event needs to be reported.
               && (outputEventCollector.hasNoGeneratedEvent()
                   || event instanceof PipeTsFileInsertionEvent
-                      && ((PipeTsFileInsertionEvent) event)
-                          .isProgressReportManagedByTsFileParser())
+                      && ((PipeTsFileInsertionEvent) event).isProgressReportManagedByTsFileParser())
               // If the event's reference count cannot be increased, it means that the event has
               // been released, and the progress of the event can not be reported.
               && !outputEventCollector.isFailedToIncreaseReferenceCount()
@@ -429,8 +427,7 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     return event;
   }
 
-  private synchronized boolean retainFailedTsFileParserEvent(
-      final PipeTsFileInsertionEvent event) {
+  private synchronized boolean retainFailedTsFileParserEvent(final PipeTsFileInsertionEvent event) {
     if (isClosed.get()) {
       if (!event.isReleased()) {
         event.clearReferenceCount(PipeProcessorSubtask.class.getName());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -71,6 +71,7 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
   private boolean isSourceTsFileProgressReferenceIncreased;
 
   private final PipeTabletMemoryBlock allocatedMemoryBlock;
+  private long memoryReservedForNextReferenceIncrease;
 
   private TabletInsertionEventParser eventParser;
 
@@ -271,10 +272,14 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
     }
 
     try {
-      PipeDataNodeResourceManager.memory()
-          .forceResize(
-              allocatedMemoryBlock,
-              PipeMemoryWeightUtil.calculateTabletSizeInBytes(tablet) + INSTANCE_SIZE);
+      final long targetMemoryInBytes = getTabletSizeInBytes() + INSTANCE_SIZE;
+      if (memoryReservedForNextReferenceIncrease > 0) {
+        PipeDataNodeResourceManager.memory()
+            .forceResizeWithReservedMemory(
+                allocatedMemoryBlock, targetMemoryInBytes, memoryReservedForNextReferenceIncrease);
+      } else {
+        PipeDataNodeResourceManager.memory().forceResize(allocatedMemoryBlock, targetMemoryInBytes);
+      }
       if (Objects.nonNull(pipeName)) {
         PipeDataNodeSinglePipeMetrics.getInstance()
             .increaseRawTabletEventCount(pipeName, creationTime);
@@ -284,6 +289,24 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
       releaseSourceTsFileProgressReference(true, false);
       throw e;
     }
+  }
+
+  public synchronized boolean increaseReferenceCountWithReservedMemory(
+      final String holderMessage, final long reservedMemoryInBytes) {
+    if (referenceCount.get() > 0) {
+      return super.increaseReferenceCount(holderMessage);
+    }
+
+    memoryReservedForNextReferenceIncrease = Math.max(0, reservedMemoryInBytes);
+    try {
+      return super.increaseReferenceCount(holderMessage);
+    } finally {
+      memoryReservedForNextReferenceIncrease = 0;
+    }
+  }
+
+  public long getTabletSizeInBytes() {
+    return PipeMemoryWeightUtil.calculateTabletSizeInBytes(tablet);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -56,6 +56,9 @@ import java.util.function.BiConsumer;
 public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
     implements TabletInsertionEvent, ReferenceTrackableEvent, AutoCloseable {
 
+  private static final String SOURCE_TSFILE_PROGRESS_HOLDER =
+      PipeRawTabletInsertionEvent.class.getName() + "#source-tsfile-progress";
+
   // For better calculation
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(PipeRawTabletInsertionEvent.class);
@@ -65,6 +68,7 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
 
   private final EnrichedEvent sourceEvent;
   private boolean needToReport;
+  private boolean isSourceTsFileProgressReferenceIncreased;
 
   private final PipeTabletMemoryBlock allocatedMemoryBlock;
 
@@ -258,15 +262,28 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
 
   @Override
   public boolean internallyIncreaseResourceReferenceCount(final String holderMessage) {
-    PipeDataNodeResourceManager.memory()
-        .forceResize(
-            allocatedMemoryBlock,
-            PipeMemoryWeightUtil.calculateTabletSizeInBytes(tablet) + INSTANCE_SIZE);
-    if (Objects.nonNull(pipeName)) {
-      PipeDataNodeSinglePipeMetrics.getInstance()
-          .increaseRawTabletEventCount(pipeName, creationTime);
+    final PipeTsFileInsertionEvent progressReportSourceTsFile = getProgressReportSourceTsFile();
+    if (progressReportSourceTsFile != null) {
+      if (!progressReportSourceTsFile.increaseReferenceCount(SOURCE_TSFILE_PROGRESS_HOLDER)) {
+        return false;
+      }
+      isSourceTsFileProgressReferenceIncreased = true;
     }
-    return true;
+
+    try {
+      PipeDataNodeResourceManager.memory()
+          .forceResize(
+              allocatedMemoryBlock,
+              PipeMemoryWeightUtil.calculateTabletSizeInBytes(tablet) + INSTANCE_SIZE);
+      if (Objects.nonNull(pipeName)) {
+        PipeDataNodeSinglePipeMetrics.getInstance()
+            .increaseRawTabletEventCount(pipeName, creationTime);
+      }
+      return true;
+    } catch (final RuntimeException e) {
+      releaseSourceTsFileProgressReference(true, false);
+      throw e;
+    }
   }
 
   @Override
@@ -303,7 +320,26 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
       }
     }
 
+    releaseSourceTsFileProgressReference(shouldReportOnCommit, !shouldReportOnCommit);
+
     return true;
+  }
+
+  private void releaseSourceTsFileProgressReference(
+      final boolean shouldReport, final boolean shouldAbortSourceProgressReport) {
+    if (!isSourceTsFileProgressReferenceIncreased) {
+      return;
+    }
+    isSourceTsFileProgressReferenceIncreased = false;
+
+    final PipeTsFileInsertionEvent progressReportSourceTsFile = getProgressReportSourceTsFile();
+    if (progressReportSourceTsFile != null && !progressReportSourceTsFile.isReleased()) {
+      if (shouldAbortSourceProgressReport) {
+        progressReportSourceTsFile.abortProgressReportManagedByTsFileParser();
+      }
+      progressReportSourceTsFile.decreaseReferenceCount(
+          SOURCE_TSFILE_PROGRESS_HOLDER, shouldReport);
+    }
   }
 
   protected void eliminateProgressIndex() {
@@ -426,6 +462,22 @@ public class PipeRawTabletInsertionEvent extends PipeInsertionEvent
 
   public EnrichedEvent getSourceEvent() {
     return sourceEvent;
+  }
+
+  public PipeTsFileInsertionEvent getProgressReportSourceTsFile() {
+    if (sourceEvent instanceof PipeTsFileInsertionEvent
+        && ((PipeTsFileInsertionEvent) sourceEvent).isProgressReportManagedByTsFileParser()) {
+      return (PipeTsFileInsertionEvent) sourceEvent;
+    }
+    if (sourceEvent instanceof PipeRawTabletInsertionEvent) {
+      return ((PipeRawTabletInsertionEvent) sourceEvent).getProgressReportSourceTsFile();
+    }
+    return null;
+  }
+
+  @Override
+  public boolean needToCommit() {
+    return getProgressReportSourceTsFile() == null;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -110,6 +110,8 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
       new AtomicReference<>();
   private final AtomicInteger parsedTabletInsertionEventCount = new AtomicInteger(0);
   private final AtomicBoolean isTsFileParsingCompleted = new AtomicBoolean(false);
+  private final AtomicBoolean isProgressReportManagedByTsFileParser = new AtomicBoolean(false);
+  private final AtomicBoolean isTsFileParserProgressReportAborted = new AtomicBoolean(false);
   private final AtomicLong parsedPointCountForCount = new AtomicLong(0);
 
   // The point count of the TsFile. Used for metrics on IoTConsensusV2' receiver side.
@@ -1092,6 +1094,10 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
         waitTimeSeconds);
   }
 
+  public boolean tryReserveTsFileParserMemory() {
+    return tryReserveTsFileParserMemory(PipeDataNodeResourceManager.memory());
+  }
+
   private boolean tryReserveTsFileParserMemory(final PipeMemoryManager memoryManager) {
     synchronized (isTsFileParserMemoryReserved) {
       if (isTsFileParserMemoryReserved.get()) {
@@ -1108,7 +1114,7 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
     }
   }
 
-  private void releaseTsFileParserMemoryIfReserved() {
+  public void releaseTsFileParserMemoryIfReserved() {
     synchronized (isTsFileParserMemoryReserved) {
       if (isTsFileParserMemoryReserved.compareAndSet(true, false)) {
         PipeDataNodeResourceManager.memory()
@@ -1132,6 +1138,27 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
 
   public boolean isGeneratedByHistoricalExtractor() {
     return isGeneratedByHistoricalExtractor;
+  }
+
+  public void markProgressReportManagedByTsFileParser() {
+    isProgressReportManagedByTsFileParser.set(true);
+  }
+
+  public boolean isProgressReportManagedByTsFileParser() {
+    return isProgressReportManagedByTsFileParser.get();
+  }
+
+  public void abortProgressReportManagedByTsFileParser() {
+    if (isProgressReportManagedByTsFileParser.get()
+        && isTsFileParserProgressReportAborted.compareAndSet(false, true)) {
+      LOGGER.warn("Abort progress report for partially transferred parsed TsFile: {}", tsFile);
+    }
+  }
+
+  @Override
+  public boolean needToCommit() {
+    return !isProgressReportManagedByTsFileParser.get()
+        || !isTsFileParserProgressReportAborted.get();
   }
 
   private TsFileInsertionEventParser initEventParser() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -692,8 +692,20 @@ public class PipeMemoryManager {
     resize(block, targetSize, true);
   }
 
-  public synchronized void resize(
-      final PipeMemoryBlock block, final long targetSize, final boolean force) {
+  public void forceResizeWithReservedMemory(
+      final PipeMemoryBlock block, final long targetSize, final long reservedMemoryInBytes) {
+    resize(block, targetSize, true, Math.max(0, reservedMemoryInBytes));
+  }
+
+  public void resize(final PipeMemoryBlock block, final long targetSize, final boolean force) {
+    resize(block, targetSize, force, 0);
+  }
+
+  private synchronized void resize(
+      final PipeMemoryBlock block,
+      final long targetSize,
+      final boolean force,
+      final long reservedMemoryInBytes) {
     if (block == null || block.isReleased()) {
       LOGGER.warn(DataNodePipeMessages.FORCERESIZE_CANNOT_RESIZE_A_NULL_OR_RELEASED);
       return;
@@ -726,15 +738,19 @@ public class PipeMemoryManager {
       return;
     }
 
-    long sizeInBytes = targetSize - oldSize;
+    final long sizeInBytes = targetSize - oldSize;
+    final long requiredFreeMemoryInBytes =
+        sizeInBytes > Long.MAX_VALUE - reservedMemoryInBytes
+            ? Long.MAX_VALUE
+            : sizeInBytes + reservedMemoryInBytes;
     final int memoryAllocateMaxRetries = PIPE_CONFIG.getPipeMemoryAllocateMaxRetries();
     for (int i = 1; i <= memoryAllocateMaxRetries; i++) {
       // Dynamically resized data-structure blocks must obey the same admission thresholds as
       // blocks allocated with a non-zero initial size. Otherwise they can exhaust the pool and
       // prevent downstream consumers from allocating the memory needed to release them.
-      if (isHardEnoughForResizing(block, sizeInBytes)
+      if (isHardEnoughForResizing(block, requiredFreeMemoryInBytes)
           && getTotalNonFloatingMemorySizeInBytes() - memoryBlock.getUsedMemoryInBytes()
-              >= sizeInBytes) {
+              >= requiredFreeMemoryInBytes) {
         memoryBlock.forceAllocateWithoutLimitation(sizeInBytes);
         if (oldSize == 0) {
           // If the memory block is not registered, we need to register it first.
@@ -753,7 +769,7 @@ public class PipeMemoryManager {
       }
 
       try {
-        tryShrinkUntilFreeMemorySatisfy(sizeInBytes);
+        tryShrinkUntilFreeMemorySatisfy(requiredFreeMemoryInBytes);
         this.wait(PIPE_CONFIG.getPipeMemoryAllocateRetryIntervalInMs());
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -765,12 +781,13 @@ public class PipeMemoryManager {
     if (force) {
       throw new PipeRuntimeOutOfMemoryCriticalException(
           String.format(
-              DataNodePipeMessages
-                  .PIPE_EXCEPTION_FORCERESIZE_FAILED_TO_ALLOCATE_MEMORY_AFTER_D_RETRIES_TOTAL_8C6948BC,
-              memoryAllocateMaxRetries,
-              getTotalNonFloatingMemorySizeInBytes(),
-              memoryBlock.getUsedMemoryInBytes(),
-              sizeInBytes));
+                  DataNodePipeMessages
+                      .PIPE_EXCEPTION_FORCERESIZE_FAILED_TO_ALLOCATE_MEMORY_AFTER_D_RETRIES_TOTAL_8C6948BC,
+                  memoryAllocateMaxRetries,
+                  getTotalNonFloatingMemorySizeInBytes(),
+                  memoryBlock.getUsedMemoryInBytes(),
+                  sizeInBytes)
+              + String.format(", reserved memory size %d bytes", reservedMemoryInBytes));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -193,9 +193,7 @@ public class PipeMemoryManager {
         enqueueTsFileParserReservationRequest(pipeRegionIdentity, reservationKey);
 
     final int globalLimit = Math.max(1, PIPE_CONFIG.getPipeTsFileParserInFlightMaxNum());
-    final int perPipeRegionLimit =
-        Math.max(
-            1, Math.min(globalLimit, PIPE_CONFIG.getPipeTsFileParserInFlightMaxNumPerPipeRegion()));
+    final int perPipeRegionLimit = getTsFileParserInFlightMaxNumPerPipeRegion(globalLimit);
     final int reservedCountOfPipeRegion =
         reservedTsFileParserCountByPipeRegion.getOrDefault(pipeRegionIdentity, 0);
     if (reservedTsFileParserCount >= globalLimit
@@ -322,9 +320,7 @@ public class PipeMemoryManager {
       return;
     }
 
-    final int perPipeRegionLimit =
-        Math.max(
-            1, Math.min(globalLimit, PIPE_CONFIG.getPipeTsFileParserInFlightMaxNumPerPipeRegion()));
+    final int perPipeRegionLimit = getTsFileParserInFlightMaxNumPerPipeRegion(globalLimit);
     final PipeRegionIdentity nextPipeRegion =
         getNextEligibleTsFileParserPipeRegion(perPipeRegionLimit, !isSoftMemoryEnough);
     if (nextPipeRegion == null) {
@@ -380,6 +376,11 @@ public class PipeMemoryManager {
       }
     }
     return firstEligiblePipeRegion;
+  }
+
+  private static int getTsFileParserInFlightMaxNumPerPipeRegion(final int globalLimit) {
+    final int configuredLimit = PIPE_CONFIG.getPipeTsFileParserInFlightMaxNumPerPipeRegion();
+    return configuredLimit <= 0 ? globalLimit : Math.min(globalLimit, configuredLimit);
   }
 
   private void clearTsFileParserAdmissionCursorIfIdle() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventBatch.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.commons.pipe.agent.task.progress.CommitterKey;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.db.i18n.DataNodePipeMessages;
 import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
-import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryBlock;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTabletMemoryBlock;
 import org.apache.iotdb.db.pipe.sink.protocol.thrift.async.IoTDBDataRegionAsyncSink;
 import org.apache.iotdb.db.storageengine.dataregion.wal.exception.WALPipeException;
 import org.apache.iotdb.pipe.api.event.Event;
@@ -49,7 +49,7 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
   private long firstEventProcessingTime = Long.MIN_VALUE;
 
   protected long totalBufferSize = 0;
-  private final PipeMemoryBlock allocatedMemoryBlock;
+  private final PipeTabletMemoryBlock allocatedMemoryBlock;
 
   protected volatile boolean isClosed = false;
 
@@ -61,7 +61,8 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
 
     // limit in buffer size
     this.maxBatchSizeInBytes = requestMaxBatchSizeInBytes;
-    this.allocatedMemoryBlock = PipeDataNodeResourceManager.memory().forceAllocate(0);
+    this.allocatedMemoryBlock =
+        PipeDataNodeResourceManager.memory().forceAllocateForTabletWithRetry(0);
     if (recordMetric != null) {
       this.recordMetric = recordMetric;
     } else {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/PropertiesTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/PropertiesTest.java
@@ -112,6 +112,10 @@ public class PropertiesTest {
 
       Assert.assertEquals(3, commonConfig.getPipeTsFileParserInFlightMaxNum());
       Assert.assertEquals(2, commonConfig.getPipeTsFileParserInFlightMaxNumPerPipeRegion());
+
+      properties.setProperty("pipe_tsfile_parser_in_flight_max_num_per_pipe_region", "0");
+      descriptor.loadHotModifiedProps(properties);
+      Assert.assertEquals(0, commonConfig.getPipeTsFileParserInFlightMaxNumPerPipeRegion());
     } finally {
       final TrimProperties properties = new TrimProperties();
       properties.setProperty(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeProcessorSubtaskExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeProcessorSubtaskExecutorTest.java
@@ -19,16 +19,29 @@
 
 package org.apache.iotdb.db.pipe.agent.task;
 
+import org.apache.iotdb.commons.pipe.agent.plugin.builtin.processor.donothing.DoNothingProcessor;
 import org.apache.iotdb.commons.pipe.agent.task.connection.EventSupplier;
+import org.apache.iotdb.commons.pipe.agent.task.execution.PipeSubtaskScheduler;
+import org.apache.iotdb.commons.pipe.event.ProgressReportEvent;
 import org.apache.iotdb.db.pipe.agent.task.connection.PipeEventCollector;
 import org.apache.iotdb.db.pipe.agent.task.execution.PipeProcessorSubtaskExecutor;
 import org.apache.iotdb.db.pipe.agent.task.subtask.processor.PipeProcessorSubtask;
+import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
+import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.pipe.api.PipeProcessor;
 
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PipeProcessorSubtaskExecutorTest extends PipeSubtaskExecutorTest {
 
@@ -46,5 +59,120 @@ public class PipeProcessorSubtaskExecutorTest extends PipeSubtaskExecutorTest {
                 mock(EventSupplier.class),
                 mock(PipeProcessor.class),
                 mock(PipeEventCollector.class)));
+  }
+
+  @Test
+  public void testProgressReportEventDoesNotWaitForInFlightTsFileParser() throws Exception {
+    assertControlEventDoesNotWaitForInFlightTsFileParser(mock(ProgressReportEvent.class), false);
+  }
+
+  @Test
+  public void testHeartbeatEventDoesNotWaitForInFlightTsFileParser() throws Exception {
+    assertControlEventDoesNotWaitForInFlightTsFileParser(mock(PipeHeartbeatEvent.class), true);
+  }
+
+  private void assertControlEventDoesNotWaitForInFlightTsFileParser(
+      final org.apache.iotdb.pipe.api.event.Event controlEvent, final boolean isHeartbeat)
+      throws Exception {
+    final EventSupplier eventSupplier = mock(EventSupplier.class);
+    final PipeEventCollector pipeEventCollector = mock(PipeEventCollector.class);
+    final PipeEventCollector firstParserCollector = mock(PipeEventCollector.class);
+    final PipeEventCollector secondParserCollector = mock(PipeEventCollector.class);
+    final PipeTsFileInsertionEvent firstTsFileEvent = mock(PipeTsFileInsertionEvent.class);
+    final PipeTsFileInsertionEvent secondTsFileEvent = mock(PipeTsFileInsertionEvent.class);
+
+    when(eventSupplier.supply())
+        .thenReturn(firstTsFileEvent, controlEvent, secondTsFileEvent, null);
+    when(pipeEventCollector.shouldParseTsFileEvent(any(PipeTsFileInsertionEvent.class)))
+        .thenReturn(true);
+    when(pipeEventCollector.forkForTsFileParser())
+        .thenReturn(firstParserCollector, secondParserCollector);
+    when(firstTsFileEvent.tryReserveTsFileParserMemory()).thenReturn(true);
+    when(secondTsFileEvent.tryReserveTsFileParserMemory()).thenReturn(true);
+
+    final CountDownLatch parsersStarted = new CountDownLatch(2);
+    final CountDownLatch releaseParsers = new CountDownLatch(1);
+    doAnswer(
+            invocation -> {
+              parsersStarted.countDown();
+              releaseParsers.await(5, TimeUnit.SECONDS);
+              return null;
+            })
+        .when(firstParserCollector)
+        .collect(firstTsFileEvent);
+    doAnswer(
+            invocation -> {
+              parsersStarted.countDown();
+              releaseParsers.await(5, TimeUnit.SECONDS);
+              return null;
+            })
+        .when(secondParserCollector)
+        .collect(secondTsFileEvent);
+
+    final TestablePipeProcessorSubtask pipeProcessorSubtask =
+        new TestablePipeProcessorSubtask(
+            isHeartbeat ? "heartbeat-barrier-test" : "progress-report-barrier-test",
+            eventSupplier,
+            pipeEventCollector);
+    try {
+      Assert.assertTrue(pipeProcessorSubtask.executeOnceForTest());
+      Assert.assertTrue(pipeProcessorSubtask.executeOnceForTest());
+      Mockito.verify(pipeEventCollector).collect(controlEvent);
+      if (isHeartbeat) {
+        Mockito.verify((PipeHeartbeatEvent) controlEvent).onProcessed();
+      }
+      Assert.assertTrue(pipeProcessorSubtask.executeOnceForTest());
+      Assert.assertTrue(parsersStarted.await(5, TimeUnit.SECONDS));
+    } finally {
+      releaseParsers.countDown();
+      pipeProcessorSubtask.close();
+    }
+  }
+
+  private static class TestablePipeProcessorSubtask extends PipeProcessorSubtask {
+
+    private TestablePipeProcessorSubtask(
+        final String taskID,
+        final EventSupplier inputEventSupplier,
+        final PipeEventCollector outputEventCollector) {
+      super(
+          taskID,
+          "pipe",
+          System.currentTimeMillis(),
+          0,
+          inputEventSupplier,
+          new DoNothingProcessor(),
+          outputEventCollector,
+          2);
+      subtaskScheduler = new SingleStepPipeSubtaskScheduler();
+      allowSubmittingSelf();
+    }
+
+    private boolean executeOnceForTest() throws Exception {
+      return call();
+    }
+  }
+
+  private static class SingleStepPipeSubtaskScheduler extends PipeSubtaskScheduler {
+
+    private boolean hasScheduled;
+
+    private SingleStepPipeSubtaskScheduler() {
+      super(null);
+    }
+
+    @Override
+    public boolean schedule() {
+      if (hasScheduled) {
+        return false;
+      }
+      hasScheduled = true;
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      hasScheduled = false;
+    }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEventTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEventTest.java
@@ -88,42 +88,15 @@ public class PipeRawTabletInsertionEventTest {
     tablet.addTimestamp(0, 1);
     tablet.addValue("s", 0, 1L);
     return new PipeRawTabletInsertionEvent(
-        null,
-        null,
-        null,
-        null,
-        tablet,
-        false,
-        "pipe",
-        1,
-        null,
-        sourceEvent,
-        needToReport);
+        null, null, null, null, tablet, false, "pipe", 1, null, sourceEvent, needToReport);
   }
 
   private static class TestPipeTsFileInsertionEvent extends PipeTsFileInsertionEvent {
 
     private TestPipeTsFileInsertionEvent(final TsFileResource resource, final File tsFile) {
       super(
-          null,
-          null,
-          resource,
-          tsFile,
-          false,
-          false,
-          false,
-          null,
-          "pipe",
-          1,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          true,
-          0,
-          1);
+          null, null, resource, tsFile, false, false, false, null, "pipe", 1, null, null, null,
+          null, null, null, true, 0, 1);
     }
 
     @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEventTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEventTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.event.common.tablet;
+
+import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
+import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.write.record.Tablet;
+import org.apache.tsfile.write.schema.MeasurementSchema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PipeRawTabletInsertionEventTest {
+
+  @Test
+  public void testFailedParsedTabletAbortsSourceProgressRegardlessOfReleaseOrder() {
+    assertFailedParsedTabletAbortsSourceProgress(true);
+    assertFailedParsedTabletAbortsSourceProgress(false);
+  }
+
+  private static void assertFailedParsedTabletAbortsSourceProgress(
+      final boolean releaseFailedTabletFirst) {
+    final TestPipeTsFileInsertionEvent sourceEvent = createProgressManagedSourceEvent();
+    final PipeRawTabletInsertionEvent failedTablet = createEvent(sourceEvent, false);
+    final PipeRawTabletInsertionEvent successfulTablet = createEvent(sourceEvent, true);
+
+    Assert.assertFalse(failedTablet.needToCommit());
+    Assert.assertFalse(successfulTablet.needToCommit());
+    Assert.assertTrue(sourceEvent.increaseReferenceCount("processor"));
+    Assert.assertTrue(failedTablet.increaseReferenceCount("collector"));
+    Assert.assertTrue(successfulTablet.increaseReferenceCount("collector"));
+    Assert.assertEquals(3, sourceEvent.getReferenceCount());
+
+    sourceEvent.decreaseReferenceCount("processor", true);
+    if (releaseFailedTabletFirst) {
+      failedTablet.clearReferenceCount("discarded");
+      successfulTablet.decreaseReferenceCount("transferred", true);
+    } else {
+      successfulTablet.decreaseReferenceCount("transferred", true);
+      failedTablet.clearReferenceCount("discarded");
+    }
+
+    Assert.assertTrue(sourceEvent.isReleased());
+    Assert.assertFalse(sourceEvent.needToCommit());
+  }
+
+  private static TestPipeTsFileInsertionEvent createProgressManagedSourceEvent() {
+    final File tsFile = new File("target/source-progress.tsfile");
+    final TsFileResource resource = mock(TsFileResource.class);
+    when(resource.getTsFile()).thenReturn(tsFile);
+    when(resource.isClosed()).thenReturn(true);
+
+    final TestPipeTsFileInsertionEvent sourceEvent =
+        new TestPipeTsFileInsertionEvent(resource, tsFile);
+    sourceEvent.markProgressReportManagedByTsFileParser();
+    return sourceEvent;
+  }
+
+  private static PipeRawTabletInsertionEvent createEvent(
+      final EnrichedEvent sourceEvent, final boolean needToReport) {
+    final MeasurementSchema schema = new MeasurementSchema("s", TSDataType.INT64);
+    final Tablet tablet = new Tablet("root.sg.d", Collections.singletonList(schema), 1);
+    tablet.addTimestamp(0, 1);
+    tablet.addValue("s", 0, 1L);
+    return new PipeRawTabletInsertionEvent(
+        null,
+        null,
+        null,
+        null,
+        tablet,
+        false,
+        "pipe",
+        1,
+        null,
+        sourceEvent,
+        needToReport);
+  }
+
+  private static class TestPipeTsFileInsertionEvent extends PipeTsFileInsertionEvent {
+
+    private TestPipeTsFileInsertionEvent(final TsFileResource resource, final File tsFile) {
+      super(
+          null,
+          null,
+          resource,
+          tsFile,
+          false,
+          false,
+          false,
+          null,
+          "pipe",
+          1,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          true,
+          0,
+          1);
+    }
+
+    @Override
+    public boolean internallyIncreaseResourceReferenceCount(final String holderMessage) {
+      return true;
+    }
+
+    @Override
+    public boolean internallyDecreaseResourceReferenceCount(final String holderMessage) {
+      return true;
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerTest.java
@@ -125,6 +125,17 @@ public class PipeMemoryManagerTest {
   }
 
   @Test
+  public void testNonPositivePerPipeRegionLimitFollowsGlobalLimit() {
+    commonConfig.setPipeTsFileParserInFlightMaxNum(2);
+    commonConfig.setPipeTsFileParserInFlightMaxNumPerPipeRegion(0);
+
+    final Reservation first = new Reservation("pipe", 1, "1");
+    final Reservation second = new Reservation("pipe", 1, "1");
+    Assert.assertTrue(tryAcquire(first));
+    Assert.assertTrue(tryAcquire(second));
+  }
+
+  @Test
   public void testDifferentRegionsOfSamePipeCanRunConcurrently() {
     commonConfig.setPipeTsFileParserInFlightMaxNum(2);
     commonConfig.setPipeTsFileParserInFlightMaxNumPerPipeRegion(1);

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -2055,10 +2055,12 @@ pipe_tsfile_parser_in_flight_max_num=0
 
 # The maximum number of TsFile parsers that can run concurrently for one DataRegion of one Pipe.
 # Different DataRegions of the same Pipe have independent limits.
-# When <= 0, use 1.
+# When <= 0, follow pipe_tsfile_parser_in_flight_max_num.
+# Per-Pipe parallel parsing remains disabled unless processor.tsfile-parser.parallelism is greater
+# than 1 for that Pipe.
 # effectiveMode: hot_reload
 # Datatype: int
-pipe_tsfile_parser_in_flight_max_num_per_pipe_region=1
+pipe_tsfile_parser_in_flight_max_num_per_pipe_region=0
 
 # The connection timeout (in milliseconds) for the thrift client.
 # effectiveMode: restart

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -142,6 +142,7 @@ public enum ThreadName {
   // -------------------------- Compute --------------------------
   PIPE_SOURCE_DISRUPTOR("Pipe-Source-Disruptor"),
   PIPE_PROCESSOR_EXECUTOR_POOL("Pipe-Processor-Executor-Pool"),
+  PIPE_TSFILE_PARSER_EXECUTOR_POOL("Pipe-TsFile-Parser-Executor-Pool"),
   PIPE_SINK_EXECUTOR_POOL("Pipe-Sink-Executor-Pool"),
   IOT_CONSENSUS_V2_EXECUTOR_POOL("Pipe-Consensus-Executor-Pool"),
   PIPE_CONFIGNODE_EXECUTOR_POOL("Pipe-ConfigNode-Executor-Pool"),
@@ -311,6 +312,7 @@ public enum ThreadName {
           Arrays.asList(
               PIPE_SOURCE_DISRUPTOR,
               PIPE_PROCESSOR_EXECUTOR_POOL,
+              PIPE_TSFILE_PARSER_EXECUTOR_POOL,
               PIPE_SINK_EXECUTOR_POOL,
               IOT_CONSENSUS_V2_EXECUTOR_POOL,
               PIPE_CONFIGNODE_EXECUTOR_POOL,

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -256,7 +256,9 @@ public class CommonConfig {
   // parser reserves pipeTsFileParserMemory bytes.
   private int pipeTsFileParserInFlightMaxNum =
       Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
-  private int pipeTsFileParserInFlightMaxNumPerPipeRegion = 1;
+  // A non-positive value follows the global parser limit. Per-Pipe parallel parsing is still
+  // disabled by default and must be enabled explicitly in processor attributes.
+  private int pipeTsFileParserInFlightMaxNumPerPipeRegion = 0;
 
   // Memory for Sink batch sending (InsertNode/TsFile, choose one)
   // 1. InsertNode: 15MB, used for batch sending data to the downstream system
@@ -1073,15 +1075,15 @@ public class CommonConfig {
 
   public void setPipeTsFileParserInFlightMaxNumPerPipeRegion(
       final int pipeTsFileParserInFlightMaxNumPerPipeRegion) {
-    final int validatedValue = Math.max(1, pipeTsFileParserInFlightMaxNumPerPipeRegion);
-    if (this.pipeTsFileParserInFlightMaxNumPerPipeRegion == validatedValue) {
+    if (this.pipeTsFileParserInFlightMaxNumPerPipeRegion
+        == pipeTsFileParserInFlightMaxNumPerPipeRegion) {
       return;
     }
-    this.pipeTsFileParserInFlightMaxNumPerPipeRegion = validatedValue;
+    this.pipeTsFileParserInFlightMaxNumPerPipeRegion = pipeTsFileParserInFlightMaxNumPerPipeRegion;
     logger.info(
         ConfigMessages.CONFIG_SET_TO,
         "pipeTsFileParserInFlightMaxNumPerPipeRegion",
-        validatedValue);
+        pipeTsFileParserInFlightMaxNumPerPipeRegion);
   }
 
   public long getPipeSinkBatchMemoryInsertNode() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/builtin/processor/donothing/DoNothingProcessor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/builtin/processor/donothing/DoNothingProcessor.java
@@ -32,13 +32,27 @@ import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
 
 import java.io.IOException;
 
+import static org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant.PROCESSOR_TSFILE_PARSER_PARALLELISM_DEFAULT_VALUE;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant.PROCESSOR_TSFILE_PARSER_PARALLELISM_KEY;
+
 @TreeModel
 @TableModel
 public class DoNothingProcessor implements PipeProcessor {
 
   @Override
-  public void validate(PipeParameterValidator validator) {
-    // do nothing
+  public void validate(final PipeParameterValidator validator) throws Exception {
+    final int parallelism =
+        validator
+            .getParameters()
+            .getIntOrDefault(
+                PROCESSOR_TSFILE_PARSER_PARALLELISM_KEY,
+                PROCESSOR_TSFILE_PARSER_PARALLELISM_DEFAULT_VALUE);
+    validator.validate(
+        value -> (Integer) value >= 1,
+        String.format(
+            "%s must be greater than or equal to 1, but got %s",
+            PROCESSOR_TSFILE_PARSER_PARALLELISM_KEY, parallelism),
+        parallelism);
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/connection/BlockingPendingQueue.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/connection/BlockingPendingQueue.java
@@ -29,11 +29,15 @@ import org.apache.iotdb.pipe.api.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 public abstract class BlockingPendingQueue<E extends Event> {
@@ -49,6 +53,13 @@ public abstract class BlockingPendingQueue<E extends Event> {
   protected final AtomicBoolean isClosed = new AtomicBoolean(false);
 
   protected final Set<CommitterKey> droppedPipeTaskKeys = ConcurrentHashMap.newKeySet();
+
+  private final Object pendingEventMemoryLock = new Object();
+  private final Map<E, PendingEventMemoryReservation> eventToMemoryReservation =
+      new IdentityHashMap<>();
+  private final Map<PendingEventMemoryReservation, Boolean> activeMemoryReservations =
+      new IdentityHashMap<>();
+  private long pendingEventMemoryUsageInBytes;
 
   protected BlockingPendingQueue(
       final BlockingQueue<E> pendingQueue, final PipeEventCounter eventCounter) {
@@ -68,6 +79,73 @@ public abstract class BlockingPendingQueue<E extends Event> {
     return offered;
   }
 
+  public PendingEventMemoryReservation waitForMemoryReservation(
+      final long eventMemoryInBytes,
+      final long maxPendingEventMemoryInBytes,
+      final BooleanSupplier shouldContinueWaiting) {
+    final long normalizedEventMemoryInBytes = Math.max(0, eventMemoryInBytes);
+    final long normalizedMaxPendingEventMemoryInBytes = Math.max(1, maxPendingEventMemoryInBytes);
+
+    synchronized (pendingEventMemoryLock) {
+      while (!isClosed.get()
+          && shouldContinueWaiting.getAsBoolean()
+          && pendingEventMemoryUsageInBytes > 0
+          && normalizedEventMemoryInBytes
+              > normalizedMaxPendingEventMemoryInBytes - pendingEventMemoryUsageInBytes) {
+        try {
+          pendingEventMemoryLock.wait(100);
+        } catch (final InterruptedException e) {
+          LOGGER.info(PipeMessages.PENDING_QUEUE_PUT_INTERRUPTED, e);
+          Thread.currentThread().interrupt();
+          return null;
+        }
+      }
+
+      if (isClosed.get() || !shouldContinueWaiting.getAsBoolean()) {
+        return null;
+      }
+
+      final PendingEventMemoryReservation reservation =
+          new PendingEventMemoryReservation(this, normalizedEventMemoryInBytes);
+      activeMemoryReservations.put(reservation, Boolean.TRUE);
+      pendingEventMemoryUsageInBytes += normalizedEventMemoryInBytes;
+      return reservation;
+    }
+  }
+
+  /** Publishes an event using bytes previously reserved by {@link #waitForMemoryReservation}. */
+  public boolean offer(final E event, final PendingEventMemoryReservation reservation) {
+    if (reservation == null || reservation.owner != this) {
+      throw new IllegalArgumentException("The memory reservation does not belong to this queue.");
+    }
+
+    synchronized (pendingEventMemoryLock) {
+      if (!checkBeforeOffer(event)) {
+        releaseMemoryReservationInternal(reservation);
+        return false;
+      }
+      if (reservation.released || reservation.published) {
+        throw new IllegalStateException("The memory reservation is no longer publishable.");
+      }
+      if (eventToMemoryReservation.containsKey(event)) {
+        releaseMemoryReservationInternal(reservation);
+        throw new IllegalStateException("The same event is already byte-accounted in the queue.");
+      }
+
+      final boolean offered = pendingQueue.offer(event);
+      if (!offered) {
+        releaseMemoryReservationInternal(reservation);
+        return false;
+      }
+
+      reservation.published = true;
+      reservation.event = event;
+      eventToMemoryReservation.put(event, reservation);
+      eventCounter.increaseEventCount(event);
+      return true;
+    }
+  }
+
   public boolean put(final E event) {
     if (!checkBeforeOffer(event)) {
       return false;
@@ -85,7 +163,7 @@ public abstract class BlockingPendingQueue<E extends Event> {
 
   public E directPoll() {
     final E event = pendingQueue.poll();
-    eventCounter.decreaseEventCount(event);
+    onEventPolled(event);
     return event;
   }
 
@@ -96,7 +174,7 @@ public abstract class BlockingPendingQueue<E extends Event> {
           pendingQueue.poll(
               PIPE_CONFIG.getPipeSubtaskExecutorPendingQueueMaxBlockingTimeMs(),
               TimeUnit.MILLISECONDS);
-      eventCounter.decreaseEventCount(event);
+      onEventPolled(event);
     } catch (final InterruptedException e) {
       LOGGER.info(PipeMessages.PENDING_QUEUE_POLL_INTERRUPTED, e);
       Thread.currentThread().interrupt();
@@ -109,10 +187,11 @@ public abstract class BlockingPendingQueue<E extends Event> {
   }
 
   public void clear() {
-    isClosed.set(true);
+    closeOffers();
     pendingQueue.clear();
     eventCounter.reset();
     droppedPipeTaskKeys.clear();
+    releaseAllMemoryReservations();
   }
 
   /** DO NOT FORGET to set eventCounter to new value after invoking this method. */
@@ -121,7 +200,8 @@ public abstract class BlockingPendingQueue<E extends Event> {
   }
 
   public void discardAllEvents() {
-    isClosed.set(true);
+    closeOffers();
+    final ArrayList<E> discardedEvents = new ArrayList<>();
     pendingQueue.removeIf(
         event -> {
           if (event instanceof EnrichedEvent) {
@@ -129,10 +209,13 @@ public abstract class BlockingPendingQueue<E extends Event> {
               eventCounter.decreaseEventCount(event);
             }
           }
+          discardedEvents.add(event);
           return true;
         });
+    discardedEvents.forEach(this::releasePendingEventMemory);
     eventCounter.reset();
     droppedPipeTaskKeys.clear();
+    releaseAllMemoryReservations();
   }
 
   public void discardEventsOfPipe(
@@ -142,6 +225,7 @@ public abstract class BlockingPendingQueue<E extends Event> {
 
   public void discardEventsOfPipe(final CommitterKey committerKey) {
     droppedPipeTaskKeys.add(committerKey);
+    final ArrayList<E> discardedEvents = new ArrayList<>();
     pendingQueue.removeIf(
         event -> {
           if (event instanceof EnrichedEvent
@@ -149,10 +233,12 @@ public abstract class BlockingPendingQueue<E extends Event> {
             if (((EnrichedEvent) event).clearReferenceCount(BlockingPendingQueue.class.getName())) {
               eventCounter.decreaseEventCount(event);
             }
+            discardedEvents.add(event);
             return true;
           }
           return false;
         });
+    discardedEvents.forEach(this::releasePendingEventMemory);
   }
 
   public boolean isEmpty() {
@@ -173,6 +259,65 @@ public abstract class BlockingPendingQueue<E extends Event> {
 
   public int getPipeHeartbeatEventCount() {
     return eventCounter.getPipeHeartbeatEventCount();
+  }
+
+  public long getPendingEventMemoryUsageInBytes() {
+    synchronized (pendingEventMemoryLock) {
+      return pendingEventMemoryUsageInBytes;
+    }
+  }
+
+  protected void onEventPolled(final E event) {
+    eventCounter.decreaseEventCount(event);
+    releasePendingEventMemory(event);
+  }
+
+  private void releasePendingEventMemory(final E event) {
+    if (event == null) {
+      return;
+    }
+    synchronized (pendingEventMemoryLock) {
+      final PendingEventMemoryReservation reservation = eventToMemoryReservation.remove(event);
+      if (reservation != null) {
+        releaseMemoryReservationInternal(reservation);
+      }
+    }
+  }
+
+  private void releaseAllMemoryReservations() {
+    synchronized (pendingEventMemoryLock) {
+      for (final PendingEventMemoryReservation reservation :
+          new ArrayList<>(activeMemoryReservations.keySet())) {
+        releaseMemoryReservationInternal(reservation);
+      }
+      eventToMemoryReservation.clear();
+      pendingEventMemoryLock.notifyAll();
+    }
+  }
+
+  private void releaseMemoryReservation(final PendingEventMemoryReservation reservation) {
+    synchronized (pendingEventMemoryLock) {
+      releaseMemoryReservationInternal(reservation);
+    }
+  }
+
+  private void releaseMemoryReservationInternal(final PendingEventMemoryReservation reservation) {
+    if (reservation.released) {
+      return;
+    }
+    reservation.released = true;
+    activeMemoryReservations.remove(reservation);
+    if (reservation.event != null) {
+      eventToMemoryReservation.remove(reservation.event);
+    }
+    pendingEventMemoryUsageInBytes -= reservation.memoryInBytes;
+    pendingEventMemoryLock.notifyAll();
+  }
+
+  private void closeOffers() {
+    synchronized (pendingEventMemoryLock) {
+      isClosed.set(true);
+    }
   }
 
   protected boolean checkBeforeOffer(final E event) {
@@ -218,5 +363,25 @@ public abstract class BlockingPendingQueue<E extends Event> {
                 key.getPipeName().equals(pipeName)
                     && key.getCreationTime() == creationTime
                     && key.getRegionId() == regionId);
+  }
+
+  public static final class PendingEventMemoryReservation implements AutoCloseable {
+
+    private final BlockingPendingQueue<?> owner;
+    private final long memoryInBytes;
+    private Object event;
+    private boolean published;
+    private boolean released;
+
+    private PendingEventMemoryReservation(
+        final BlockingPendingQueue<?> owner, final long memoryInBytes) {
+      this.owner = owner;
+      this.memoryInBytes = memoryInBytes;
+    }
+
+    @Override
+    public void close() {
+      owner.releaseMemoryReservation(this);
+    }
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/connection/UnboundedBlockingPendingQueue.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/connection/UnboundedBlockingPendingQueue.java
@@ -40,7 +40,7 @@ public class UnboundedBlockingPendingQueue<E extends Event> extends BlockingPend
 
   public E pollLast() {
     final E event = pendingDeque.pollLast();
-    eventCounter.decreaseEventCount(event);
+    onEventPolled(event);
     return event;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/constant/PipeProcessorConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/constant/PipeProcessorConstant.java
@@ -27,6 +27,10 @@ public class PipeProcessorConstant {
 
   public static final String PROCESSOR_KEY = "processor";
 
+  public static final String PROCESSOR_TSFILE_PARSER_PARALLELISM_KEY =
+      "processor.tsfile-parser.parallelism";
+  public static final int PROCESSOR_TSFILE_PARSER_PARALLELISM_DEFAULT_VALUE = 1;
+
   public static final String PROCESSOR_DOWN_SAMPLING_SPLIT_FILE_KEY =
       "processor.down-sampling.split-file";
   public static final boolean PROCESSOR_DOWN_SAMPLING_SPLIT_FILE_DEFAULT_VALUE = false;

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/agent/task/connection/UnboundedBlockingPendingQueueTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/agent/task/connection/UnboundedBlockingPendingQueueTest.java
@@ -25,6 +25,11 @@ import org.apache.iotdb.pipe.api.event.Event;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class UnboundedBlockingPendingQueueTest {
@@ -41,6 +46,64 @@ public class UnboundedBlockingPendingQueueTest {
 
     Assert.assertSame(event, queue.pollLast());
     Assert.assertEquals(0, eventCounter.getEventCount());
+  }
+
+  @Test
+  public void pollReleasesPendingEventMemoryReservation() {
+    final UnboundedBlockingPendingQueue<Event> queue =
+        new UnboundedBlockingPendingQueue<>(new CountingEventCounter());
+    final Event event = new Event() {};
+    final BlockingPendingQueue.PendingEventMemoryReservation reservation =
+        queue.waitForMemoryReservation(6, 10, () -> true);
+
+    Assert.assertNotNull(reservation);
+    Assert.assertTrue(queue.offer(event, reservation));
+    Assert.assertEquals(6, queue.getPendingEventMemoryUsageInBytes());
+
+    Assert.assertSame(event, queue.directPoll());
+    Assert.assertEquals(0, queue.getPendingEventMemoryUsageInBytes());
+    reservation.close();
+  }
+
+  @Test
+  public void pendingEventMemoryReservationWaitsForQueueDrain() throws Exception {
+    final UnboundedBlockingPendingQueue<Event> queue =
+        new UnboundedBlockingPendingQueue<>(new CountingEventCounter());
+    final Event firstEvent = new Event() {};
+    final BlockingPendingQueue.PendingEventMemoryReservation firstReservation =
+        queue.waitForMemoryReservation(6, 10, () -> true);
+    Assert.assertNotNull(firstReservation);
+    Assert.assertTrue(queue.offer(firstEvent, firstReservation));
+
+    final CountDownLatch reservationAttempted = new CountDownLatch(1);
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      final Future<BlockingPendingQueue.PendingEventMemoryReservation> secondReservationFuture =
+          executor.submit(
+              () ->
+                  queue.waitForMemoryReservation(
+                      6,
+                      10,
+                      () -> {
+                        reservationAttempted.countDown();
+                        return true;
+                      }));
+
+      Assert.assertTrue(reservationAttempted.await(5, TimeUnit.SECONDS));
+      Assert.assertFalse(secondReservationFuture.isDone());
+
+      Assert.assertSame(firstEvent, queue.directPoll());
+      final BlockingPendingQueue.PendingEventMemoryReservation secondReservation =
+          secondReservationFuture.get(5, TimeUnit.SECONDS);
+      Assert.assertNotNull(secondReservation);
+      Assert.assertEquals(6, queue.getPendingEventMemoryUsageInBytes());
+
+      secondReservation.close();
+      Assert.assertEquals(0, queue.getPendingEventMemoryUsageInBytes());
+    } finally {
+      executor.shutdownNow();
+      queue.clear();
+    }
   }
 
   private static class CountingEventCounter extends PipeEventCounter {

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePluginTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePluginTest.java
@@ -40,6 +40,8 @@ import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.mockito.Mockito.mock;
 
 public class BuiltinPipePluginTest {
@@ -75,7 +77,7 @@ public class BuiltinPipePluginTest {
 
     PipeProcessor processor = new DoNothingProcessor();
     try {
-      processor.validate(mock(PipeParameterValidator.class));
+      processor.validate(new PipeParameterValidator(new PipeParameters(Collections.emptyMap())));
     } catch (Exception ignored) {
       Assert.fail();
     }


### PR DESCRIPTION
## Description

### Pooled TsFile parsing

- Adds the per-pipe processor attribute `processor.tsfile-parser.parallelism`.
- Runs built-in `DoNothingProcessor` TsFile parsing in a shared parser pool while keeping custom processors single-threaded.
- Uses the existing global and per-pipe-region parser admission limits, with non-positive per-pipe-region values following the global limit.

### Ordering, lifecycle, and memory safety

- Preserves ordered progress reporting across concurrently parsed TsFiles and keeps dependent events behind the parser barrier.
- Allows heartbeat and progress-report control events to bypass the parser barrier.
- Preserves parser state across retryable failures and handles STOP/START or task close without losing the current TsFile.
- Bounds parsed-tablet output queue memory and reserves downstream tablet capacity to avoid parser/sink memory deadlocks.

### Scope

This ports the TsFile parser pooling changes from the hotfix branch to master. The TsFile local sink implementation, writer, sink-specific tests, and the local-sink-based parser pool IT are intentionally excluded.

### Verification

```text
.\mvnw.cmd -pl iotdb-core/datanode -am -Dtest=UnboundedBlockingPendingQueueTest,PipeProcessorSubtaskExecutorTest,PipeRawTabletInsertionEventTest,PipeMemoryManagerTest,PipeEventCollectorTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 28 reactor modules succeeded. Node-commons tests: 3 passed. Datanode tests: 19 passed. Checkstyle and Spotless passed.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] considered concurrent read and write behavior.
- [x] added or updated configuration documentation.
- [x] added comments explaining non-obvious ordering, retry, and memory behavior.
- [x] added or updated unit tests for the new code paths.

<hr>

##### Key changed/added classes

- `PipeProcessorSubtask`
- `PipeEventCollector`
- `PipeTsFileInsertionEvent`
- `PipeRawTabletInsertionEvent`
- `PipeMemoryManager`
- `BlockingPendingQueue`
