### PR TITLE
[Load] Preserve pending tablets when parser fails during fallback

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/converter/LoadTreeStatementDataTypeConvertExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/converter/LoadTreeStatementDataTypeConvertExecutionVisitor.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.db.pipe.resource.memory.PipeMemoryWeightUtil.calculateTabletSizeInBytes;
@@ -57,6 +58,7 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
           .getLoadTsFileTabletConversionBatchMemorySizeInBytes();
 
   private final StatementExecutor statementExecutor;
+  private final Function<File, LoadTreeTsFileTabletIterator> tabletIteratorFactory;
 
   @FunctionalInterface
   public interface StatementExecutor {
@@ -65,7 +67,14 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
 
   public LoadTreeStatementDataTypeConvertExecutionVisitor(
       final StatementExecutor statementExecutor) {
+    this(statementExecutor, file -> new LoadTreeTsFileTabletIterator(file, true));
+  }
+
+  LoadTreeStatementDataTypeConvertExecutionVisitor(
+      final StatementExecutor statementExecutor,
+      final Function<File, LoadTreeTsFileTabletIterator> tabletIteratorFactory) {
     this.statementExecutor = statementExecutor;
+    this.tabletIteratorFactory = tabletIteratorFactory;
   }
 
   @Override
@@ -87,11 +96,24 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
     boolean shouldReleaseContext = !isManagedTask;
 
     try {
+      if (conversionContext.deferredStatus != null) {
+        final TSStatus result =
+            flushPendingTablets(conversionContext, loadTsFileStatement.isConvertOnTypeMismatch());
+        if (!handleTSStatus(result, loadTsFileStatement)) {
+          shouldReleaseContext = !isManagedTask || !isTemporaryUnavailable(result);
+          return Optional.of(result);
+        }
+        final TSStatus deferredStatus = conversionContext.deferredStatus;
+        conversionContext.deferredStatus = null;
+        shouldReleaseContext = true;
+        return Optional.of(deferredStatus);
+      }
+
       final List<File> files = loadTsFileStatement.getTsFiles();
       while (conversionContext.fileIndex < files.size()) {
         if (conversionContext.tabletIterator == null) {
           conversionContext.tabletIterator =
-              new LoadTreeTsFileTabletIterator(files.get(conversionContext.fileIndex), true);
+              tabletIteratorFactory.apply(files.get(conversionContext.fileIndex));
         }
 
         if (conversionContext.deferredTabletRawReq != null) {
@@ -164,11 +186,29 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
               .STORAGE_LOG_FAILED_TO_CONVERT_DATA_TYPE_FOR_LOADTSFILESTATEMENT_5D132E57,
           loadTsFileStatement,
           e);
+      final boolean retryable = isRetryableConversionException(e);
       final TSStatus status =
           loadTsFileStatement.accept(
               LoadTsFileDataTypeConverter.TREE_STATEMENT_EXCEPTION_VISITOR, e);
-      shouldReleaseContext =
-          !isManagedTask || !LoadTsFileDataTypeConverter.isMemoryPressureException(e);
+
+      // A parser can fail after producing tablets that are still waiting for the next batch
+      // boundary. Submit those tablets before reporting the parser error so the error does not
+      // discard successfully converted data.
+      if (!retryable && !conversionContext.tabletRawReqs.isEmpty()) {
+        final TSStatus flushStatus =
+            flushPendingTablets(conversionContext, loadTsFileStatement.isConvertOnTypeMismatch());
+        if (!handleTSStatus(flushStatus, loadTsFileStatement)) {
+          if (isManagedTask && isTemporaryUnavailable(flushStatus)) {
+            conversionContext.deferredStatus = status;
+            shouldReleaseContext = false;
+          } else {
+            shouldReleaseContext = true;
+          }
+          return Optional.of(flushStatus);
+        }
+      }
+
+      shouldReleaseContext = !isManagedTask || !retryable;
       return Optional.of(status);
     } finally {
       if (shouldReleaseContext) {
@@ -201,6 +241,21 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
                 == TSStatusCode.PIPE_RECEIVER_TEMPORARY_UNAVAILABLE_EXCEPTION.getStatusCode());
   }
 
+  private static boolean isRetryableConversionException(final Throwable throwable) {
+    if (LoadTsFileDataTypeConverter.isMemoryPressureException(throwable)) {
+      return true;
+    }
+
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof InterruptedException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
   private static void deleteSourceFiles(final LoadTsFileStatement statement) {
     statement
         .getTsFiles()
@@ -228,6 +283,7 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
     private Pair<Tablet, Boolean> deferredTabletWithIsAligned;
     private PipeTransferTabletRawReq deferredTabletRawReq;
     private long deferredTabletRawReqSize;
+    private TSStatus deferredStatus;
 
     private void addTablet(final PipeTransferTabletRawReq request, final long size) {
       tabletRawReqs.add(request);
@@ -259,6 +315,7 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitor
       deferredTabletWithIsAligned = null;
       deferredTabletRawReq = null;
       deferredTabletRawReqSize = 0;
+      deferredStatus = null;
       block.close();
     }
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/load/converter/LoadTreeStatementDataTypeConvertExecutionVisitorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/load/converter/LoadTreeStatementDataTypeConvertExecutionVisitorTest.java
@@ -40,6 +40,7 @@ import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.common.Path;
+import org.apache.tsfile.utils.Pair;
 import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
@@ -111,6 +112,32 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitorTest {
     final int loadedPointCountAfterFallback = pointCountByDevice.getOrDefault(DEVICE_2, 0);
     Assert.assertTrue(loadedPointCountBeforeCorruption > 0);
     Assert.assertEquals(loadedPointCountBeforeCorruption, loadedPointCountAfterFallback);
+  }
+
+  @Test
+  public void testFlushesPendingTabletsWhenIteratorFails() throws Exception {
+    tsFile = File.createTempFile("load-tree-pending-tablet", ".tsfile");
+    final List<IMeasurementSchema> schemaList =
+        Arrays.asList(new MeasurementSchema("s0", TSDataType.INT64, TSEncoding.PLAIN));
+    final Tablet tablet = new Tablet(DEVICE_0, schemaList, 1);
+    tablet.addTimestamp(0, 1);
+    tablet.addValue("s0", 0, 1L);
+
+    final Map<String, Integer> pointCountByDevice = new HashMap<>();
+    final LoadTreeStatementDataTypeConvertExecutionVisitor visitor =
+        new LoadTreeStatementDataTypeConvertExecutionVisitor(
+            statement -> {
+              collectLoadedPoints(statement, pointCountByDevice);
+              return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+            },
+            file -> new ThrowingTabletIterator(file, tablet));
+
+    final Optional<TSStatus> status =
+        visitor.visitLoadFile(LoadTsFileStatement.createUnchecked(tsFile.getAbsolutePath()), null);
+
+    Assert.assertTrue(status.isPresent());
+    Assert.assertEquals(TSStatusCode.LOAD_FILE_ERROR.getStatusCode(), status.get().getCode());
+    Assert.assertEquals(1, pointCountByDevice.getOrDefault(DEVICE_0, 0).intValue());
   }
 
   @Test
@@ -419,6 +446,38 @@ public class LoadTreeStatementDataTypeConvertExecutionVisitorTest {
 
     private static void setPipeMemoryManagementEnabled(final boolean enabled) {
       CommonDescriptor.getInstance().getConfig().setPipeMemoryManagementEnabled(enabled);
+    }
+  }
+
+  private static class ThrowingTabletIterator extends LoadTreeTsFileTabletIterator {
+    private final Pair<Tablet, Boolean> tabletWithIsAligned;
+    private boolean tabletAvailable = true;
+
+    private ThrowingTabletIterator(final File file, final Tablet tablet) {
+      super(file, true);
+      tabletWithIsAligned = new Pair<>(tablet, false);
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (tabletAvailable) {
+        return true;
+      }
+      throw new IllegalStateException("synthetic parser failure");
+    }
+
+    @Override
+    public Pair<Tablet, Boolean> next() {
+      if (!tabletAvailable) {
+        throw new IllegalStateException("synthetic parser failure");
+      }
+      tabletAvailable = false;
+      return tabletWithIsAligned;
+    }
+
+    @Override
+    public void close() {
+      // No parser resources are allocated by this test iterator.
     }
   }
 }


### PR DESCRIPTION
## Problem
When tree-model Load falls back from scan parsing to query parsing, a parser exception can occur after earlier Tablets have been converted but before the pending batch reaches its normal flush boundary. The exception path released the conversion context and discarded that batch.

## Fix
Flush pending Tablets before returning a normal parser error. Temporary-unavailable results retain the pending batch and original parser status for the next managed-task retry; memory-pressure and interruption exceptions keep their existing retry behavior.

## Tests
- `mvn -pl iotdb-core/datanode -am test -Dtest=LoadTreeStatementDataTypeConvertExecutionVisitorTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -DskipITs`
- Spotless check
- Checkstyle: 0 violations

The separate exact-query versus wildcard-query observation is intentionally out of scope.