### PR TITLE
[To dev/1.3] Stabilize air-gap batch compression IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeSinkCompressionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeSinkCompressionIT.java
@@ -137,6 +137,8 @@ public class IoTDBPipeSinkCompressionIT extends AbstractPipeDualAutoIT {
           TestUtils.executeNonQueryWithRetry(senderEnv, "flush");
           TestUtils.executeNonQueryWithRetry(receiverEnv, "flush");
         };
+    final Consumer<String> senderOnlyFailure =
+        o -> TestUtils.executeNonQueryWithRetry(senderEnv, "flush");
 
     try (final SyncConfigNodeIServiceClient client =
         (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
@@ -198,7 +200,7 @@ public class IoTDBPipeSinkCompressionIT extends AbstractPipeDualAutoIT {
           "select count(*) from root.**",
           "count(root.db.d1.s1),",
           Collections.singleton("8,"),
-          handleFailure);
+          senderOnlyFailure);
     }
   }
 


### PR DESCRIPTION
## Description

Backport `dc47a3baa0a7a932bec09a831f8b43f1859a8c16` to `dev/1.3`.

For the final eventual assertion in `IoTDBPipeSinkCompressionIT`, retry failures now flush only the sender. Flushing the receiver at this point can interfere with air-gap batch transfer and make the compression IT unstable.

## Validation

- `mvn spotless:apply -pl integration-test -P with-integration-tests`
- `git diff --check origin/dev/1.3...HEAD`
- Targeted `IoTDBPipeSinkCompressionIT` verification was attempted, but the local JVM ran out of native memory while compiling the DataNode module, before the IT executed.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] modified an existing integration test.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `IoTDBPipeSinkCompressionIT`