### PR TITLE
[Pipe] Fix conversion task ID collision after leader switch

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/request/PipeTransferTsFileSealWithModReq.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/request/PipeTransferTsFileSealWithModReq.java
@@ -162,12 +162,11 @@ public class PipeTransferTsFileSealWithModReq extends PipeTransferFileSealReqV2 
         } catch (final UnsupportedOperationException ignored) {
           appendStablePart(eventIdentity, UNSUPPORTED_REPLICATE_INDEX);
         }
-        if (event.getCommitterKey() == null) {
-          try {
-            appendStablePart(eventIdentity, String.valueOf(event.getProgressIndex()));
-          } catch (final UnsupportedOperationException ignored) {
-            appendStablePart(eventIdentity, UNSUPPORTED_PROGRESS_INDEX);
-          }
+        // Commit ids are local to a DataNode and may collide after a leader change.
+        try {
+          appendStablePart(eventIdentity, String.valueOf(event.getProgressIndex()));
+        } catch (final UnsupportedOperationException ignored) {
+          appendStablePart(eventIdentity, UNSUPPORTED_PROGRESS_INDEX);
         }
         eventIdentities.add(eventIdentity.toString());
       }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/sink/PipeDataNodeThriftRequestTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/sink/PipeDataNodeThriftRequestTest.java
@@ -19,7 +19,10 @@
 
 package org.apache.iotdb.db.pipe.sink;
 
+import org.apache.iotdb.commons.consensus.index.impl.IoTProgressIndex;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.pipe.agent.task.progress.CommitterKey;
+import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.sink.payload.thrift.common.PipeTransferHandshakeConstant;
 import org.apache.iotdb.commons.pipe.sink.payload.thrift.request.IoTDBSinkRequestVersion;
 import org.apache.iotdb.commons.pipe.sink.payload.thrift.request.PipeRequestType;
@@ -71,6 +74,7 @@ import org.apache.tsfile.write.schema.IMeasurementSchema;
 import org.apache.tsfile.write.schema.MeasurementSchema;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -1213,6 +1217,32 @@ public class PipeDataNodeThriftRequestTest {
         PipeTransferTsFileSealWithModReq.fromTPipeTransferReq(request);
     Assert.assertEquals(taskId, deserialized.getConversionTaskId());
     Assert.assertFalse(deserialized.shouldAsyncLoadOnTypeMismatch());
+  }
+
+  @Test
+  public void testPipeTransferTsFileSealConversionTaskIdDistinguishesProgressIndexes() {
+    final CommitterKey committerKey = new CommitterKey("pipe", 1L, 1, 0);
+    final EnrichedEvent firstEvent = Mockito.mock(EnrichedEvent.class);
+    Mockito.when(firstEvent.getCommitterKey()).thenReturn(committerKey);
+    Mockito.when(firstEvent.getCommitIds()).thenReturn(Collections.singletonList(1L));
+    Mockito.when(firstEvent.getProgressIndex()).thenReturn(new IoTProgressIndex(1, 1L));
+
+    final EnrichedEvent secondEvent = Mockito.mock(EnrichedEvent.class);
+    Mockito.when(secondEvent.getCommitterKey()).thenReturn(committerKey);
+    Mockito.when(secondEvent.getCommitIds()).thenReturn(Collections.singletonList(1L));
+    Mockito.when(secondEvent.getProgressIndex()).thenReturn(new IoTProgressIndex(1, 100L));
+
+    final String firstTaskId =
+        PipeTransferTsFileSealWithModReq.generateConversionTaskId(
+            "sink-task", Collections.singletonList(firstEvent), "root.db", 0);
+    Assert.assertEquals(
+        firstTaskId,
+        PipeTransferTsFileSealWithModReq.generateConversionTaskId(
+            "sink-task", Collections.singletonList(firstEvent), "root.db", 0));
+    Assert.assertNotEquals(
+        firstTaskId,
+        PipeTransferTsFileSealWithModReq.generateConversionTaskId(
+            "sink-task", Collections.singletonList(secondEvent), "root.db", 0));
   }
 
   @Test


### PR DESCRIPTION
## What is changed

Include each event progress index in the TsFile conversion task identity, even when a committer key is present. Commit IDs are DataNode-local and can repeat after a leader change; omitting the progress index can make two different snapshots look like the same conversion task and cause the receiver to acknowledge the newer file without loading it.

## Scope

This task ID is used by sync, async, and air-gap transfer paths. The fix preserves stable IDs for retries of the same progress while separating different historical snapshots.

## Tests

- Added regression coverage for identical committer/commit IDs with different progress indexes.
- Direct JUnit execution of PipeDataNodeThriftRequestTest: 46 tests passed.
- git diff --check passed.

The full Maven test lifecycle is currently blocked before test execution by unrelated stale/generated Freemarker compilation errors in the DataNode module.