### PR TITLE
fix: fix `RPCTransportFactory` setting bug

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -543,12 +543,13 @@ public class IoTDBConnection implements Connection {
   }
 
   private void openTransport() throws TTransportException {
-    DeepCopyRpcTransportFactory.setDefaultBufferCapacity(params.getThriftDefaultBufferSize());
-    DeepCopyRpcTransportFactory.setThriftMaxFrameSize(params.getThriftMaxFrameSize());
+    DeepCopyRpcTransportFactory transportFactory =
+        DeepCopyRpcTransportFactory.getInstance(
+            params.getThriftDefaultBufferSize(), params.getThriftMaxFrameSize());
 
     if (params.isUseSSL()) {
       transport =
-          DeepCopyRpcTransportFactory.INSTANCE.getTransport(
+          transportFactory.getTransport(
               params.getHost(),
               params.getPort(),
               getNetworkTimeout(),
@@ -559,8 +560,7 @@ public class IoTDBConnection implements Connection {
               params.getSslProtocol());
     } else {
       transport =
-          DeepCopyRpcTransportFactory.INSTANCE.getTransport(
-              params.getHost(), params.getPort(), getNetworkTimeout());
+          transportFactory.getTransport(params.getHost(), params.getPort(), getNetworkTimeout());
     }
     if (!transport.isOpen()) {
       transport.open();

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactory.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactory.java
@@ -21,13 +21,7 @@ package org.apache.iotdb.rpc;
 
 import org.apache.thrift.transport.TTransportFactory;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 public class DeepCopyRpcTransportFactory extends BaseRpcTransportFactory {
-
-  private static final Map<FactoryConfig, DeepCopyRpcTransportFactory> INSTANCES =
-      new ConcurrentHashMap<>();
 
   public static DeepCopyRpcTransportFactory INSTANCE;
 
@@ -45,10 +39,7 @@ public class DeepCopyRpcTransportFactory extends BaseRpcTransportFactory {
 
   public static DeepCopyRpcTransportFactory getInstance(
       int thriftDefaultBufferSize, int thriftMaxFrameSize) {
-    FactoryConfig config =
-        new FactoryConfig(USE_SNAPPY, thriftDefaultBufferSize, thriftMaxFrameSize);
-    return INSTANCES.computeIfAbsent(
-        config, key -> create(key.useSnappy, key.thriftDefaultBufferSize, key.thriftMaxFrameSize));
+    return create(USE_SNAPPY, thriftDefaultBufferSize, thriftMaxFrameSize);
   }
 
   private static DeepCopyRpcTransportFactory create(
@@ -61,7 +52,4 @@ public class DeepCopyRpcTransportFactory extends BaseRpcTransportFactory {
             new TimeoutChangeableTFastFramedTransport.Factory(
                 thriftDefaultBufferSize, thriftMaxFrameSize, true));
   }
-
-  private record FactoryConfig(
-      boolean useSnappy, int thriftDefaultBufferSize, int thriftMaxFrameSize) {}
 }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactory.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactory.java
@@ -21,7 +21,13 @@ package org.apache.iotdb.rpc;
 
 import org.apache.thrift.transport.TTransportFactory;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class DeepCopyRpcTransportFactory extends BaseRpcTransportFactory {
+
+  private static final Map<FactoryConfig, DeepCopyRpcTransportFactory> INSTANCES =
+      new ConcurrentHashMap<>();
 
   public static DeepCopyRpcTransportFactory INSTANCE;
 
@@ -34,13 +40,28 @@ public class DeepCopyRpcTransportFactory extends BaseRpcTransportFactory {
   }
 
   public static void reInit() {
-    INSTANCE =
-        USE_SNAPPY
-            ? new DeepCopyRpcTransportFactory(
-                new TimeoutChangeableTSnappyFramedTransport.Factory(
-                    thriftDefaultBufferSize, thriftMaxFrameSize, true))
-            : new DeepCopyRpcTransportFactory(
-                new TimeoutChangeableTFastFramedTransport.Factory(
-                    thriftDefaultBufferSize, thriftMaxFrameSize, true));
+    INSTANCE = create(USE_SNAPPY, thriftDefaultBufferSize, thriftMaxFrameSize);
   }
+
+  public static DeepCopyRpcTransportFactory getInstance(
+      int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    FactoryConfig config =
+        new FactoryConfig(USE_SNAPPY, thriftDefaultBufferSize, thriftMaxFrameSize);
+    return INSTANCES.computeIfAbsent(
+        config, key -> create(key.useSnappy, key.thriftDefaultBufferSize, key.thriftMaxFrameSize));
+  }
+
+  private static DeepCopyRpcTransportFactory create(
+      boolean useSnappy, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    return useSnappy
+        ? new DeepCopyRpcTransportFactory(
+            new TimeoutChangeableTSnappyFramedTransport.Factory(
+                thriftDefaultBufferSize, thriftMaxFrameSize, true))
+        : new DeepCopyRpcTransportFactory(
+            new TimeoutChangeableTFastFramedTransport.Factory(
+                thriftDefaultBufferSize, thriftMaxFrameSize, true));
+  }
+
+  private record FactoryConfig(
+      boolean useSnappy, int thriftDefaultBufferSize, int thriftMaxFrameSize) {}
 }

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactoryTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactoryTest.java
@@ -27,9 +27,17 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
 
 public class DeepCopyRpcTransportFactoryTest {
+
+  @Test
+  public void testGetInstanceReturnsIndependentClientFactories() {
+    assertNotSame(
+        DeepCopyRpcTransportFactory.getInstance(8, 16),
+        DeepCopyRpcTransportFactory.getInstance(8, 16));
+  }
 
   @Test
   public void testIndependentMaxFrameSizeConfigurations() throws TTransportException {

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactoryTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.rpc;
+
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class DeepCopyRpcTransportFactoryTest {
+
+  @Test
+  public void testIndependentMaxFrameSizeConfigurations() throws TTransportException {
+    TTransport smallFrameTransport = createTransport(16, 20);
+    TTransportException exception =
+        assertThrows(
+            TTransportException.class, () -> smallFrameTransport.read(ByteBuffer.allocate(1)));
+    assertEquals("Frame size (20) larger than protect max size (16)!", exception.getMessage());
+
+    TTransport largeFrameTransport = createTransport(32, 20);
+    assertEquals(1, largeFrameTransport.read(ByteBuffer.allocate(1)));
+  }
+
+  private static TTransport createTransport(int maxFrameSize, int frameSize)
+      throws TTransportException {
+    ByteBuffer frame = ByteBuffer.allocate(Integer.BYTES + frameSize);
+    frame.putInt(frameSize);
+    frame.put(new byte[frameSize]);
+    return DeepCopyRpcTransportFactory.getInstance(8, maxFrameSize)
+        .getTransport(new TMemoryInputTransport(frame.array()));
+  }
+}

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -196,15 +196,16 @@ public class SessionConnection {
       String keyStorePwd,
       String sslProtocol)
       throws IoTDBConnectionException, StatementExecutionException {
-    DeepCopyRpcTransportFactory.setDefaultBufferCapacity(session.thriftDefaultBufferSize);
-    DeepCopyRpcTransportFactory.setThriftMaxFrameSize(session.thriftMaxFrameSize);
+    DeepCopyRpcTransportFactory transportFactory =
+        DeepCopyRpcTransportFactory.getInstance(
+            session.thriftDefaultBufferSize, session.thriftMaxFrameSize);
     try {
       if (transport != null && transport.isOpen()) {
         close();
       }
       if (useSSL) {
         transport =
-            DeepCopyRpcTransportFactory.INSTANCE.getTransport(
+            transportFactory.getTransport(
                 endPoint.getIp(),
                 endPoint.getPort(),
                 session.connectionTimeoutInMs,
@@ -215,7 +216,7 @@ public class SessionConnection {
                 sslProtocol);
       } else {
         transport =
-            DeepCopyRpcTransportFactory.INSTANCE.getTransport(
+            transportFactory.getTransport(
                 // as there is a try-catch already, we do not need to use TSocket.wrap
                 endPoint.getIp(), endPoint.getPort(), session.connectionTimeoutInMs);
       }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/ThriftConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/ThriftConnection.java
@@ -87,12 +87,12 @@ public class ThriftConnection {
       ZoneId zoneId,
       String version)
       throws IoTDBConnectionException {
-    DeepCopyRpcTransportFactory.setDefaultBufferCapacity(thriftDefaultBufferSize);
-    DeepCopyRpcTransportFactory.setThriftMaxFrameSize(thriftMaxFrameSize);
+    DeepCopyRpcTransportFactory transportFactory =
+        DeepCopyRpcTransportFactory.getInstance(thriftDefaultBufferSize, thriftMaxFrameSize);
     try {
       if (useSSL) {
         transport =
-            DeepCopyRpcTransportFactory.INSTANCE.getTransport(
+            transportFactory.getTransport(
                 endPoint.getIp(),
                 endPoint.getPort(),
                 connectionTimeoutInMs,
@@ -103,7 +103,7 @@ public class ThriftConnection {
                 sslProtocol);
       } else {
         transport =
-            DeepCopyRpcTransportFactory.INSTANCE.getTransport(
+            transportFactory.getTransport(
                 // as there is a try-catch already, we do not need to use TSocket.wrap
                 endPoint.getIp(), endPoint.getPort(), connectionTimeoutInMs);
       }


### PR DESCRIPTION
## Description

Fix #18475 
Fix the RPC transport factory cache so clients with different Thrift buffer and maximum frame-size configurations do not share an incorrectly configured singleton.

### Content

- Cache `DeepCopyRpcTransportFactory` instances by compression mode, buffer size, and maximum frame size.
- Update Session and JDBC clients to obtain the factory using their own configuration.
- Preserve the existing server-side `INSTANCE` and `reInit()` behavior.
- Add a regression test verifying that different maximum frame sizes work independently.

The new behavier would act as:
```java
DeepCopyRpcTransportFactory factory =
    DeepCopyRpcTransportFactory.getInstance(bufferSize, maxFrameSize);

transport = factory.getTransport(...);
```

<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [x] concurrent write
    - [x] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
