### PR TITLE
Fix flaky CompactionWorkerTest by replacing fixed sleep with CountDownLatch

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionWorkerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionWorkerTest.java
@@ -95,6 +95,15 @@ public class CompactionWorkerTest {
             0);
     CrossSpaceCompactionTask taskMock = Mockito.spy(task);
     Mockito.doReturn(true).when(taskMock).start();
+    CountDownLatch statusResetLatch = new CountDownLatch(1);
+    Mockito.doAnswer(
+            invocation -> {
+              invocation.callRealMethod();
+              statusResetLatch.countDown();
+              return null;
+            })
+        .when(taskMock)
+        .resetCompactionCandidateStatusForAllSourceFiles();
     FixedPriorityBlockingQueue<AbstractCompactionTask> queue =
         new CompactionTaskQueue(50, new DefaultCompactionTaskComparatorImpl());
     queue.put(taskMock);
@@ -108,7 +117,9 @@ public class CompactionWorkerTest {
               }
             });
     thread.start();
-    thread.join(TimeUnit.SECONDS.toMillis(2));
+    Assert.assertTrue(
+        "source files should be reset to NORMAL after the cross-space task is dropped",
+        statusResetLatch.await(5, TimeUnit.SECONDS));
     Assert.assertEquals(
         0, SystemInfo.getInstance().getCompactionMemoryBlock().getUsedMemoryInBytes());
     Assert.assertEquals(0, SystemInfo.getInstance().getCompactionFileNumCost().get());
@@ -153,6 +164,15 @@ public class CompactionWorkerTest {
               0L, tsFileManager, sequenceFiles, unsequenceFiles, null, 1000, 0);
       CrossSpaceCompactionTask taskMock = Mockito.spy(task);
       Mockito.doReturn(true).when(taskMock).start();
+      CountDownLatch statusResetLatch = new CountDownLatch(1);
+      Mockito.doAnswer(
+              invocation -> {
+                invocation.callRealMethod();
+                statusResetLatch.countDown();
+                return null;
+              })
+          .when(taskMock)
+          .resetCompactionCandidateStatusForAllSourceFiles();
       FixedPriorityBlockingQueue<AbstractCompactionTask> queue =
           new CompactionTaskQueue(50, new DefaultCompactionTaskComparatorImpl());
       queue.put(taskMock);
@@ -165,7 +185,9 @@ public class CompactionWorkerTest {
                 }
               });
       thread.start();
-      thread.join(TimeUnit.SECONDS.toMillis(2));
+      Assert.assertTrue(
+          "source files should be reset to NORMAL after the cross-space task is dropped",
+          statusResetLatch.await(5, TimeUnit.SECONDS));
       Assert.assertEquals(
           0, SystemInfo.getInstance().getCompactionMemoryBlock().getUsedMemoryInBytes());
       Assert.assertEquals(0, SystemInfo.getInstance().getCompactionFileNumCost().get());
@@ -208,9 +230,19 @@ public class CompactionWorkerTest {
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0L, tsFileManager, sequenceFiles, unsequenceFiles, null, 1000, 0);
+    CrossSpaceCompactionTask taskMock = Mockito.spy(task);
+    CountDownLatch statusResetLatch = new CountDownLatch(1);
+    Mockito.doAnswer(
+            invocation -> {
+              invocation.callRealMethod();
+              statusResetLatch.countDown();
+              return null;
+            })
+        .when(taskMock)
+        .resetCompactionCandidateStatusForAllSourceFiles();
     FixedPriorityBlockingQueue<AbstractCompactionTask> queue =
         new CompactionTaskQueue(50, new DefaultCompactionTaskComparatorImpl());
-    queue.put(task);
+    queue.put(taskMock);
     Thread thread =
         new Thread(
             () -> {
@@ -220,7 +252,9 @@ public class CompactionWorkerTest {
               }
             });
     thread.start();
-    thread.join(TimeUnit.SECONDS.toMillis(2));
+    Assert.assertTrue(
+        "source files should be reset to NORMAL after the cross-space task is dropped",
+        statusResetLatch.await(5, TimeUnit.SECONDS));
     Assert.assertEquals(
         0, SystemInfo.getInstance().getCompactionMemoryBlock().getUsedMemoryInBytes());
     Assert.assertEquals(0, SystemInfo.getInstance().getCompactionFileNumCost().get());
@@ -248,9 +282,19 @@ public class CompactionWorkerTest {
     // fail to check valid when tsfile manager is not allowed to compaction in inner task
     InnerSpaceCompactionTask innerTask =
         new InnerSpaceCompactionTask(0L, tsFileManager, sequenceFiles, true, null, 0L);
+    InnerSpaceCompactionTask innerTaskMock = Mockito.spy(innerTask);
+    CountDownLatch statusResetLatch = new CountDownLatch(1);
+    Mockito.doAnswer(
+            invocation -> {
+              invocation.callRealMethod();
+              statusResetLatch.countDown();
+              return null;
+            })
+        .when(innerTaskMock)
+        .resetCompactionCandidateStatusForAllSourceFiles();
     FixedPriorityBlockingQueue<AbstractCompactionTask> queue =
         new CompactionTaskQueue(50, new DefaultCompactionTaskComparatorImpl());
-    queue.put(innerTask);
+    queue.put(innerTaskMock);
     Thread thread =
         new Thread(
             () -> {
@@ -260,7 +304,9 @@ public class CompactionWorkerTest {
               }
             });
     thread.start();
-    thread.join(TimeUnit.SECONDS.toMillis(2));
+    Assert.assertTrue(
+        "source files should be reset to NORMAL after the inner-space task is dropped",
+        statusResetLatch.await(5, TimeUnit.SECONDS));
     Assert.assertEquals(
         0, SystemInfo.getInstance().getCompactionMemoryBlock().getUsedMemoryInBytes());
     Assert.assertEquals(0, SystemInfo.getInstance().getCompactionFileNumCost().get());


### PR DESCRIPTION
## Problem

`CompactionWorkerTest.testFailedToAllocateFileNumInCrossTask` and `testFailedToCheckValidInCrossTask` intermittently fail with:

```
expected:<NORMAL> but was:<COMPACTION_CANDIDATE>
```

The tests use `thread.join(2s)` to wait for the compaction task to be dropped. However, in these failure cases `queue.take()` never returns: the task is dropped by `CompactionTaskQueue.prepareTask -> dropCompactionTask`, which calls `resetCompactionCandidateStatusForAllSourceFiles()` to change the source files from `COMPACTION_CANDIDATE` back to `NORMAL`. The worker thread then loops back and waits on the empty queue.

The fixed 2-second join only waits for elapsed time, not for the actual state transition. Under load or scheduling delay, the main thread can assert before the worker thread performs the status reset, producing the flaky failure.

## Fix

Replace the timing-based wait with a `CountDownLatch` triggered inside the worker thread at the exact state-transition point. A Mockito `doAnswer` hook calls `countDown()` right after `resetCompactionCandidateStatusForAllSourceFiles()` completes:

```java
CountDownLatch statusResetLatch = new CountDownLatch(1);
Mockito.doAnswer(invocation -> {
  invocation.callRealMethod();
  statusResetLatch.countDown();
  return null;
}).when(taskMock).resetCompactionCandidateStatusForAllSourceFiles();

thread.start();
Assert.assertTrue(statusResetLatch.await(5, TimeUnit.SECONDS));
```

This waits for the exact condition (source files back to `NORMAL`) with a 5-second timeout, making the tests deterministic instead of relying on arbitrary sleep.

Applied to all four task-drop tests in `CompactionWorkerTest` that used the same pattern.