### PR TITLE
Fix snapshot pipe auto-drop when some DataNodes fail to initialize

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/heartbeat/DataNodeHeartbeatHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/heartbeat/DataNodeHeartbeatHandler.java
@@ -192,7 +192,8 @@ public class DataNodeHeartbeatHandler implements AsyncMethodCallback<TDataNodeHe
           heartbeatResp.getPipeRemainingEventCountList(),
           heartbeatResp.getPipeRemainingTimeList(),
           heartbeatResp.getPipeDegradedStatusList(),
-          heartbeatResp.getPipeRecentFailureList());
+          heartbeatResp.getPipeRecentFailureList(),
+          heartbeatResp.getPipeCompletedDataRegionList());
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -3339,7 +3339,8 @@ public class ConfigManager implements IManager {
             resp.getPipeRemainingEventCountList(),
             resp.getPipeRemainingTimeList(),
             resp.getPipeDegradedStatusList(),
-            resp.getPipeRecentFailureList());
+            resp.getPipeRecentFailureList(),
+            resp.getPipeCompletedDataRegionList());
     return StatusUtils.OK;
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/PipeRuntimeCoordinator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/PipeRuntimeCoordinator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.confignode.manager.pipe.coordinator.runtime;
 
+import org.apache.iotdb.common.rpc.thrift.TPipeCompletedDataRegion;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.confignode.manager.ConfigManager;
@@ -98,7 +99,8 @@ public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
       /* @Nullable */ final List<Long> pipeRemainingEventCountListFromAgent,
       /* @Nullable */ final List<Double> pipeRemainingTimeListFromAgent,
       /* @Nullable */ final List<Integer> pipeDegradedStatusListFromAgent,
-      /* @Nullable */ final List<Map<String, Long>> pipeRecentFailureListFromAgent) {
+      /* @Nullable */ final List<Map<String, Long>> pipeRecentFailureListFromAgent,
+      /* @Nullable */ final List<TPipeCompletedDataRegion> pipeCompletedDataRegionListFromAgent) {
     pipeHeartbeatScheduler.parseHeartbeat(
         dataNodeId,
         new PipeHeartbeat(
@@ -107,6 +109,7 @@ public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
             pipeRemainingEventCountListFromAgent,
             pipeRemainingTimeListFromAgent,
             pipeDegradedStatusListFromAgent,
-            pipeRecentFailureListFromAgent));
+            pipeRecentFailureListFromAgent,
+            pipeCompletedDataRegionListFromAgent));
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeat.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeat.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.confignode.manager.pipe.coordinator.runtime.heartbeat;
 
+import org.apache.iotdb.common.rpc.thrift.TPipeCompletedDataRegion;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTemporaryMeta;
@@ -32,11 +33,11 @@ import java.util.Objects;
 
 public class PipeHeartbeat {
   private final Map<PipeStaticMeta, PipeMeta> pipeMetaMap = new HashMap<>();
-  private final Map<PipeStaticMeta, Boolean> isCompletedMap = new HashMap<>();
   private final Map<PipeStaticMeta, Long> remainingEventCountMap = new HashMap<>();
   private final Map<PipeStaticMeta, Double> remainingTimeMap = new HashMap<>();
   private final Map<PipeStaticMeta, Boolean> isDegradedMap = new HashMap<>();
   private final Map<PipeStaticMeta, Map<String, Long>> recentFailuresMap = new HashMap<>();
+  private final Map<PipeStaticMeta, List<Integer>> completedDataRegionIdsMap = new HashMap<>();
 
   public PipeHeartbeat(
       final List<ByteBuffer> pipeMetaByteBufferListFromAgent,
@@ -50,6 +51,7 @@ public class PipeHeartbeat {
         pipeRemainingEventCountListFromAgent,
         pipeRemainingTimeListFromAgent,
         pipeDegradedStatusListFromAgent,
+        null,
         null);
   }
 
@@ -60,6 +62,24 @@ public class PipeHeartbeat {
       /* @Nullable */ final List<Double> pipeRemainingTimeListFromAgent,
       /* @Nullable */ final List<Integer> pipeDegradedStatusListFromAgent,
       /* @Nullable */ final List<Map<String, Long>> pipeRecentFailureListFromAgent) {
+    this(
+        pipeMetaByteBufferListFromAgent,
+        pipeCompletedListFromAgent,
+        pipeRemainingEventCountListFromAgent,
+        pipeRemainingTimeListFromAgent,
+        pipeDegradedStatusListFromAgent,
+        pipeRecentFailureListFromAgent,
+        null);
+  }
+
+  public PipeHeartbeat(
+      final List<ByteBuffer> pipeMetaByteBufferListFromAgent,
+      /* @Nullable */ final List<Boolean> pipeCompletedListFromAgent,
+      /* @Nullable */ final List<Long> pipeRemainingEventCountListFromAgent,
+      /* @Nullable */ final List<Double> pipeRemainingTimeListFromAgent,
+      /* @Nullable */ final List<Integer> pipeDegradedStatusListFromAgent,
+      /* @Nullable */ final List<Map<String, Long>> pipeRecentFailureListFromAgent,
+      /* @Nullable */ final List<TPipeCompletedDataRegion> completedDataRegionListFromAgent) {
     // Shall not reach here, just in case
     if (Objects.isNull(pipeMetaByteBufferListFromAgent)) {
       return;
@@ -68,11 +88,6 @@ public class PipeHeartbeat {
       final PipeMeta pipeMeta =
           PipeMeta.deserialize4TaskAgent(pipeMetaByteBufferListFromAgent.get(i));
       pipeMetaMap.put(pipeMeta.getStaticMeta(), pipeMeta);
-      isCompletedMap.put(
-          pipeMeta.getStaticMeta(),
-          Objects.nonNull(pipeCompletedListFromAgent)
-              && i < pipeCompletedListFromAgent.size()
-              && pipeCompletedListFromAgent.get(i));
       // If remaining event count & remaining time can not be got, it implies that the heartbeat is
       // from an ancient version of DataNode. Here we guarantee that "0" will not affect both of
       // the final results and namely these dataNodes are omitted in calculation.
@@ -102,6 +117,17 @@ public class PipeHeartbeat {
                   && Objects.nonNull(pipeRecentFailureListFromAgent.get(i))
               ? new HashMap<>(pipeRecentFailureListFromAgent.get(i))
               : Collections.emptyMap());
+      if (completedDataRegionListFromAgent != null) {
+        for (final TPipeCompletedDataRegion completedDataRegion :
+            completedDataRegionListFromAgent) {
+          if (pipeMeta.getStaticMeta().getPipeName().equals(completedDataRegion.getPipeName())
+              && pipeMeta.getStaticMeta().getCreationTime()
+                  == completedDataRegion.getCreationTime()) {
+            completedDataRegionIdsMap.put(
+                pipeMeta.getStaticMeta(), completedDataRegion.getCompletedDataRegionIds());
+          }
+        }
+      }
     }
   }
 
@@ -113,8 +139,12 @@ public class PipeHeartbeat {
     return pipeMetaMap.get(pipeStaticMeta);
   }
 
-  public Boolean isCompleted(final PipeStaticMeta pipeStaticMeta) {
-    return isCompletedMap.get(pipeStaticMeta);
+  public List<Integer> getCompletedDataRegionIds(final PipeStaticMeta pipeStaticMeta) {
+    return completedDataRegionIdsMap.getOrDefault(pipeStaticMeta, Collections.emptyList());
+  }
+
+  public boolean hasCompletedDataRegionReport(final PipeStaticMeta pipeStaticMeta) {
+    return completedDataRegionIdsMap.containsKey(pipeStaticMeta);
   }
 
   public Long getRemainingEventCount(final PipeStaticMeta pipeStaticMeta) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParser.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParser.java
@@ -39,6 +39,7 @@ import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -156,40 +157,48 @@ public class PipeHeartbeatParser {
       final PipeTemporaryMetaInCoordinator temporaryMeta =
           (PipeTemporaryMetaInCoordinator) pipeMetaFromCoordinator.getTemporaryMeta();
 
+      final Set<Integer> expectedDataNodeIds = getExpectedDataNodeIds(pipeMetaFromCoordinator);
+
       // Remove completed pipes
       final Boolean isPipeCompletedFromAgent = pipeHeartbeat.isCompleted(staticMeta);
       if (Boolean.TRUE.equals(isPipeCompletedFromAgent)) {
 
-        temporaryMeta.markDataNodeCompleted(nodeId);
-        PipeLogger.log(
-            LOGGER::info,
-            ManagerMessages.DETECTED_HISTORICAL_PIPE_COMPLETION_REPORT_FROM_DATANODE,
-            nodeId,
-            staticMeta.getPipeName(),
-            pipeHeartbeat.getRemainingEventCount(staticMeta),
-            pipeHeartbeat.getRemainingTime(staticMeta),
-            temporaryMeta.getCompletedDataNodeIds());
+        if (expectedDataNodeIds.contains(nodeId)) {
+          temporaryMeta.markDataNodeCompleted(nodeId);
+          PipeLogger.log(
+              LOGGER::info,
+              ManagerMessages.DETECTED_HISTORICAL_PIPE_COMPLETION_REPORT_FROM_DATANODE,
+              nodeId,
+              staticMeta.getPipeName(),
+              pipeHeartbeat.getRemainingEventCount(staticMeta),
+              pipeHeartbeat.getRemainingTime(staticMeta),
+              temporaryMeta.getCompletedDataNodeIds());
+        }
 
-        final Set<Integer> uncompletedDataNodeIds =
-            configManager.getNodeManager().getRegisteredDataNodeLocations().keySet();
-        uncompletedDataNodeIds.removeAll(temporaryMeta.getCompletedDataNodeIds());
-        if (uncompletedDataNodeIds.isEmpty()) {
-          PipeLogger.log(
-              LOGGER::info,
-              ManagerMessages.ALL_DATANODES_REPORTED_HISTORICAL_PIPE_COMPLETED,
-              staticMeta.getPipeName(),
-              temporaryMeta.getGlobalRemainingEvents(),
-              temporaryMeta.getGlobalRemainingTime(),
-              staticMeta);
-          pipeTaskInfo.get().removePipeMeta(staticMeta);
-          PipeLogger.log(
-              LOGGER::info,
-              ManagerMessages.DETECTED_COMPLETION_OF_PIPE_STATIC_META_REMOVE_IT,
-              staticMeta.getPipeName(),
-              staticMeta);
-          needWriteConsensusOnConfigNodes.set(true);
-          needPushPipeMetaToDataNodes.set(true);
-          continue;
+        // Only DataNodes that are expected to run this Pipe participate in the completion
+        // judgment. A DataNode that does not own any target region should not block the Pipe
+        // from being automatically dropped after all expected DataNodes complete.
+        if (!expectedDataNodeIds.isEmpty()) {
+          final Set<Integer> uncompletedDataNodeIds = new HashSet<>(expectedDataNodeIds);
+          uncompletedDataNodeIds.removeAll(temporaryMeta.getCompletedDataNodeIds());
+          if (uncompletedDataNodeIds.isEmpty()) {
+            PipeLogger.log(
+                LOGGER::info,
+                ManagerMessages.ALL_DATANODES_REPORTED_HISTORICAL_PIPE_COMPLETED,
+                staticMeta.getPipeName(),
+                temporaryMeta.getGlobalRemainingEvents(),
+                temporaryMeta.getGlobalRemainingTime(),
+                staticMeta);
+            pipeTaskInfo.get().removePipeMeta(staticMeta);
+            PipeLogger.log(
+                LOGGER::info,
+                ManagerMessages.DETECTED_COMPLETION_OF_PIPE_STATIC_META_REMOVE_IT,
+                staticMeta.getPipeName(),
+                staticMeta);
+            needWriteConsensusOnConfigNodes.set(true);
+            needPushPipeMetaToDataNodes.set(true);
+            continue;
+          }
         }
       }
 
@@ -330,5 +339,23 @@ public class PipeHeartbeatParser {
         }
       }
     }
+  }
+
+  // Returns the DataNodes that must complete this Pipe. It derives the expected set from the pipe's
+  // runtime metadata instead of all registered DataNodes, so DataNodes that do not own any target
+  // region are ignored during the auto-drop completion check.
+  private Set<Integer> getExpectedDataNodeIds(final PipeMeta pipeMeta) {
+    final Set<Integer> registeredDataNodeIds =
+        configManager.getNodeManager().getRegisteredDataNodeLocations().keySet();
+    final Set<Integer> expectedDataNodeIds = new HashSet<>();
+    for (final Map.Entry<Integer, PipeTaskMeta> entry :
+        pipeMeta.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().entrySet()) {
+      // The ConfigRegion task is led by a ConfigNode, not by a DataNode.
+      if (entry.getKey() != Integer.MIN_VALUE
+          && registeredDataNodeIds.contains(entry.getValue().getLeaderNodeId())) {
+        expectedDataNodeIds.add(entry.getValue().getLeaderNodeId());
+      }
+    }
+    return expectedDataNodeIds;
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParser.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParser.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.confignode.manager.pipe.coordinator.runtime.heartbeat;
 
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeCriticalException;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeException;
@@ -157,49 +159,48 @@ public class PipeHeartbeatParser {
       final PipeTemporaryMetaInCoordinator temporaryMeta =
           (PipeTemporaryMetaInCoordinator) pipeMetaFromCoordinator.getTemporaryMeta();
 
-      final Set<Integer> expectedDataNodeIds = getExpectedDataNodeIds(pipeMetaFromCoordinator);
-
-      // Remove completed pipes
-      final Boolean isPipeCompletedFromAgent = pipeHeartbeat.isCompleted(staticMeta);
-      if (Boolean.TRUE.equals(isPipeCompletedFromAgent)) {
-
-        if (expectedDataNodeIds.contains(nodeId)) {
-          temporaryMeta.markDataNodeCompleted(nodeId);
-          PipeLogger.log(
-              LOGGER::info,
-              ManagerMessages.DETECTED_HISTORICAL_PIPE_COMPLETION_REPORT_FROM_DATANODE,
-              nodeId,
-              staticMeta.getPipeName(),
-              pipeHeartbeat.getRemainingEventCount(staticMeta),
-              pipeHeartbeat.getRemainingTime(staticMeta),
-              temporaryMeta.getCompletedDataNodeIds());
+      // Aggregate completed DataRegion ids reported by DataNodes. Only the DataNodes that own the
+      // target region can report it, so the coordinator can compare the union against all required
+      // DataRegion ids without trusting any DataNode's single per-pipe completion boolean.
+      if (pipeHeartbeat.hasCompletedDataRegionReport(staticMeta)) {
+        for (final Integer completedDataRegionId :
+            pipeHeartbeat.getCompletedDataRegionIds(staticMeta)) {
+          temporaryMeta.markDataRegionCompleted(completedDataRegionId);
         }
+      }
 
-        // Only DataNodes that are expected to run this Pipe participate in the completion
-        // judgment. A DataNode that does not own any target region should not block the Pipe
-        // from being automatically dropped after all expected DataNodes complete.
-        if (!expectedDataNodeIds.isEmpty()) {
-          final Set<Integer> uncompletedDataNodeIds = new HashSet<>(expectedDataNodeIds);
-          uncompletedDataNodeIds.removeAll(temporaryMeta.getCompletedDataNodeIds());
-          if (uncompletedDataNodeIds.isEmpty()) {
-            PipeLogger.log(
-                LOGGER::info,
-                ManagerMessages.ALL_DATANODES_REPORTED_HISTORICAL_PIPE_COMPLETED,
-                staticMeta.getPipeName(),
-                temporaryMeta.getGlobalRemainingEvents(),
-                temporaryMeta.getGlobalRemainingTime(),
-                staticMeta);
-            pipeTaskInfo.get().removePipeMeta(staticMeta);
-            PipeLogger.log(
-                LOGGER::info,
-                ManagerMessages.DETECTED_COMPLETION_OF_PIPE_STATIC_META_REMOVE_IT,
-                staticMeta.getPipeName(),
-                staticMeta);
-            needWriteConsensusOnConfigNodes.set(true);
-            needPushPipeMetaToDataNodes.set(true);
-            continue;
-          }
+      final Set<Integer> requiredDataRegionIds = new HashSet<>();
+      for (final Map.Entry<Integer, PipeTaskMeta> entry :
+          pipeMetaFromCoordinator.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().entrySet()) {
+        if (configManager
+            .getPartitionManager()
+            .isRegionGroupExists(
+                new TConsensusGroupId(TConsensusGroupType.DataRegion, entry.getKey()))) {
+          requiredDataRegionIds.add(entry.getKey());
         }
+      }
+
+      // Remove completed pipes only when every required DataRegion has been reported complete.
+      // Relying on the region-level reports (instead of the DataNode-level boolean) prevents a
+      // leader-change / task-creation failure from being treated as a successful snapshot transfer.
+      if (!requiredDataRegionIds.isEmpty()
+          && temporaryMeta.getCompletedDataRegionIds().containsAll(requiredDataRegionIds)) {
+        PipeLogger.log(
+            LOGGER::info,
+            ManagerMessages.ALL_DATANODES_REPORTED_HISTORICAL_PIPE_COMPLETED,
+            staticMeta.getPipeName(),
+            temporaryMeta.getGlobalRemainingEvents(),
+            temporaryMeta.getGlobalRemainingTime(),
+            staticMeta);
+        pipeTaskInfo.get().removePipeMeta(staticMeta);
+        PipeLogger.log(
+            LOGGER::info,
+            ManagerMessages.DETECTED_COMPLETION_OF_PIPE_STATIC_META_REMOVE_IT,
+            staticMeta.getPipeName(),
+            staticMeta);
+        needWriteConsensusOnConfigNodes.set(true);
+        needPushPipeMetaToDataNodes.set(true);
+        continue;
       }
 
       // Record statistics
@@ -339,23 +340,5 @@ public class PipeHeartbeatParser {
         }
       }
     }
-  }
-
-  // Returns the DataNodes that must complete this Pipe. It derives the expected set from the pipe's
-  // runtime metadata instead of all registered DataNodes, so DataNodes that do not own any target
-  // region are ignored during the auto-drop completion check.
-  private Set<Integer> getExpectedDataNodeIds(final PipeMeta pipeMeta) {
-    final Set<Integer> registeredDataNodeIds =
-        configManager.getNodeManager().getRegisteredDataNodeLocations().keySet();
-    final Set<Integer> expectedDataNodeIds = new HashSet<>();
-    for (final Map.Entry<Integer, PipeTaskMeta> entry :
-        pipeMeta.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().entrySet()) {
-      // The ConfigRegion task is led by a ConfigNode, not by a DataNode.
-      if (entry.getKey() != Integer.MIN_VALUE
-          && registeredDataNodeIds.contains(entry.getValue().getLeaderNodeId())) {
-        expectedDataNodeIds.add(entry.getValue().getLeaderNodeId());
-      }
-    }
-    return expectedDataNodeIds;
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatScheduler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatScheduler.java
@@ -117,7 +117,8 @@ public class PipeHeartbeatScheduler {
                         resp.getPipeRemainingEventCountList(),
                         resp.getPipeRemainingTimeList(),
                         resp.getPipeDegradedStatusList(),
-                        resp.getPipeRecentFailureList())));
+                        resp.getPipeRecentFailureList(),
+                        resp.getPipeCompletedDataRegionList())));
 
     // config node heartbeat
     try {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -34,7 +34,6 @@ import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTemporaryMeta;
-import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTemporaryMetaInCoordinator;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeType;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant;
@@ -917,9 +916,6 @@ public class PipeTaskInfo implements SnapshotProcessor {
                               consensusGroupIdToTaskMetaMap
                                   .get(consensusGroupId.getId())
                                   .setLeaderNodeId(newLeader);
-                              // New region leader may contain un-transferred events
-                              ((PipeTemporaryMetaInCoordinator) pipeMeta.getTemporaryMeta())
-                                  .markDataNodeUncompleted(newLeader);
                             } else {
                               consensusGroupIdToTaskMetaMap.remove(consensusGroupId.getId());
                             }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParserTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParserTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.confignode.manager.pipe.coordinator.runtime.heartbeat;
 
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.common.rpc.thrift.TPipeCompletedDataRegion;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeCriticalException;
@@ -33,6 +35,7 @@ import org.apache.iotdb.confignode.consensus.request.write.pipe.task.CreatePipeP
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.ProcedureManager;
 import org.apache.iotdb.confignode.manager.node.NodeManager;
+import org.apache.iotdb.confignode.manager.partition.PartitionManager;
 import org.apache.iotdb.confignode.manager.pipe.coordinator.PipeManager;
 import org.apache.iotdb.confignode.manager.pipe.coordinator.runtime.PipeRuntimeCoordinator;
 import org.apache.iotdb.confignode.manager.pipe.coordinator.task.PipeTaskCoordinator;
@@ -47,6 +50,7 @@ import org.mockito.Mockito;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -360,6 +364,105 @@ public class PipeHeartbeatParserTest {
     Assert.assertTrue(heartbeat.getRecentFailures(pipeMeta.getStaticMeta()).isEmpty());
   }
 
+  @Test
+  public void testParseHeartbeatDoesNotCompleteWhenRequiredDataRegionMissing() throws Exception {
+    CommonDescriptor.getInstance().getConfig().setSeperatedPipeHeartbeatEnabled(false);
+
+    final PipeTaskInfo pipeTaskInfo = new PipeTaskInfo();
+    final PipeMeta pipeMeta = createPipeMeta();
+    pipeTaskInfo.createPipe(
+        new CreatePipePlanV2(pipeMeta.getStaticMeta(), pipeMeta.getRuntimeMeta()));
+
+    final ParserTestContext context = createParserTestContext(1, pipeTaskInfo);
+    context.parser.parseHeartbeat(
+        1,
+        new PipeHeartbeat(
+            Collections.singletonList(pipeMeta.serialize()),
+            Collections.singletonList(true),
+            Collections.singletonList(0L),
+            Collections.singletonList(0d),
+            null,
+            null,
+            Collections.singletonList(
+                new TPipeCompletedDataRegion(
+                    pipeMeta.getStaticMeta().getPipeName(),
+                    pipeMeta.getStaticMeta().getCreationTime(),
+                    Collections.emptyList()))));
+
+    Assert.assertTrue(getTemporaryMeta(pipeTaskInfo).getCompletedDataRegionIds().isEmpty());
+    Assert.assertNotNull(pipeTaskInfo.getPipeMetaByPipeName("test_pipe"));
+    verify(context.procedureManager, never()).pipeHandleMetaChange(anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  public void testParseHeartbeatDoesNotTrustDataNodeBooleanForCompletion() throws Exception {
+    CommonDescriptor.getInstance().getConfig().setSeperatedPipeHeartbeatEnabled(false);
+
+    final PipeTaskInfo pipeTaskInfo = new PipeTaskInfo();
+    final PipeMeta pipeMeta = createPipeMeta(1);
+    pipeTaskInfo.createPipe(
+        new CreatePipePlanV2(pipeMeta.getStaticMeta(), pipeMeta.getRuntimeMeta()));
+
+    final ParserTestContext context = createParserTestContext(1, pipeTaskInfo);
+    // The DataNode's boolean is false, but the required DataRegion is reported complete. The
+    // coordinator should still complete the pipe because it no longer trusts the boolean.
+    context.parser.parseHeartbeat(
+        1, createPipeHeartbeatWithCompletedRegions(pipeMeta, false, Collections.singletonList(1)));
+
+    Assert.assertNull(pipeTaskInfo.getPipeMetaByPipeName("test_pipe"));
+  }
+
+  @Test
+  public void testParseHeartbeatCompletesOnlyAfterAllRequiredDataRegionsReported()
+      throws Exception {
+    CommonDescriptor.getInstance().getConfig().setSeperatedPipeHeartbeatEnabled(false);
+
+    final PipeTaskInfo pipeTaskInfo = new PipeTaskInfo();
+    final PipeMeta pipeMeta = createPipeMeta(1, 2);
+    pipeMeta.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().get(2).setLeaderNodeId(2);
+    pipeTaskInfo.createPipe(
+        new CreatePipePlanV2(pipeMeta.getStaticMeta(), pipeMeta.getRuntimeMeta()));
+
+    final ParserTestContext context = createParserTestContext(2, pipeTaskInfo);
+
+    context.parser.parseHeartbeat(
+        1, createPipeHeartbeatWithCompletedRegions(pipeMeta, true, Collections.singletonList(1)));
+    Assert.assertNotNull(pipeTaskInfo.getPipeMetaByPipeName("test_pipe"));
+
+    context.parser.parseHeartbeat(
+        2, createPipeHeartbeatWithCompletedRegions(pipeMeta, true, Collections.singletonList(2)));
+    Assert.assertNull(pipeTaskInfo.getPipeMetaByPipeName("test_pipe"));
+    // After CN decides the pipe is complete, the next heartbeat round pushes the updated meta so
+    // DataNodes will drop their local pipe tasks.
+    verify(context.procedureManager, times(1)).pipeHandleMetaChange(true, true);
+  }
+
+  @Test
+  public void testParseHeartbeatKeepsCompletedDataRegionAfterLeaderChange() throws Exception {
+    CommonDescriptor.getInstance().getConfig().setSeperatedPipeHeartbeatEnabled(false);
+
+    final PipeTaskInfo pipeTaskInfo = new PipeTaskInfo();
+    final PipeMeta pipeMeta = createPipeMeta(1, 2);
+    pipeMeta.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().get(2).setLeaderNodeId(2);
+    pipeTaskInfo.createPipe(
+        new CreatePipePlanV2(pipeMeta.getStaticMeta(), pipeMeta.getRuntimeMeta()));
+
+    final ParserTestContext context = createParserTestContext(2, pipeTaskInfo);
+
+    // The old leader of region 1 reports it complete before the leader changes.
+    context.parser.parseHeartbeat(
+        1, createPipeHeartbeatWithCompletedRegions(pipeMeta, true, Collections.singletonList(1)));
+    Assert.assertNotNull(pipeTaskInfo.getPipeMetaByPipeName("test_pipe"));
+
+    // Region 1's leader moves to node 2, which only reports region 2. Region 1's completion is
+    // still valid because its historical data was already transferred by the old leader.
+    pipeMeta.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().get(1).setLeaderNodeId(2);
+    context.parser.parseHeartbeat(
+        2, createPipeHeartbeatWithCompletedRegions(pipeMeta, true, Collections.singletonList(2)));
+
+    Assert.assertNull(pipeTaskInfo.getPipeMetaByPipeName("test_pipe"));
+  }
+
   private ParserTestContext createParserTestContext(final int registeredDataNodeCount) {
     return createParserTestContext(registeredDataNodeCount, new PipeTaskInfo());
   }
@@ -373,6 +476,7 @@ public class PipeHeartbeatParserTest {
     final PipeRuntimeCoordinator pipeRuntimeCoordinator =
         Mockito.mock(PipeRuntimeCoordinator.class);
     final PipeTaskCoordinator pipeTaskCoordinator = Mockito.mock(PipeTaskCoordinator.class);
+    final PartitionManager partitionManager = Mockito.mock(PartitionManager.class);
     final ExecutorService procedureSubmitter = Mockito.mock(ExecutorService.class);
 
     when(configManager.getNodeManager()).thenReturn(nodeManager);
@@ -382,6 +486,8 @@ public class PipeHeartbeatParserTest {
     when(pipeManager.getPipeRuntimeCoordinator()).thenReturn(pipeRuntimeCoordinator);
     when(pipeManager.getPipeTaskCoordinator()).thenReturn(pipeTaskCoordinator);
     when(pipeRuntimeCoordinator.getProcedureSubmitter()).thenReturn(procedureSubmitter);
+    when(configManager.getPartitionManager()).thenReturn(partitionManager);
+    when(partitionManager.isRegionGroupExists(any(TConsensusGroupId.class))).thenReturn(true);
     when(pipeTaskCoordinator.tryLock()).thenReturn(new AtomicReference<>(pipeTaskInfo));
     when(procedureManager.pipeHandleMetaChange(anyBoolean(), anyBoolean())).thenReturn(true);
     Mockito.doAnswer(
@@ -467,13 +573,35 @@ public class PipeHeartbeatParserTest {
   }
 
   private PipeMeta createPipeMeta() {
+    return createPipeMeta(1);
+  }
+
+  private PipeMeta createPipeMeta(final int... regionIds) {
     final PipeRuntimeMeta pipeRuntimeMeta = new PipeRuntimeMeta();
-    pipeRuntimeMeta
-        .getConsensusGroupId2TaskMetaMap()
-        .put(1, new PipeTaskMeta(MinimumProgressIndex.INSTANCE, 1));
+    for (final int regionId : regionIds) {
+      pipeRuntimeMeta
+          .getConsensusGroupId2TaskMetaMap()
+          .put(regionId, new PipeTaskMeta(MinimumProgressIndex.INSTANCE, 1));
+    }
     return new PipeMeta(
         new PipeStaticMeta("test_pipe", 1L, new HashMap<>(), new HashMap<>(), new HashMap<>()),
         pipeRuntimeMeta);
+  }
+
+  private PipeHeartbeat createPipeHeartbeatWithCompletedRegions(
+      final PipeMeta pipeMeta, final boolean isCompleted, final List<Integer> completedRegionIds) {
+    return new PipeHeartbeat(
+        Collections.singletonList(pipeMeta.serialize()),
+        Collections.singletonList(isCompleted),
+        Collections.singletonList(0L),
+        Collections.singletonList(0d),
+        null,
+        null,
+        Collections.singletonList(
+            new TPipeCompletedDataRegion(
+                pipeMeta.getStaticMeta().getPipeName(),
+                pipeMeta.getStaticMeta().getCreationTime(),
+                completedRegionIds)));
   }
 
   private PipeHeartbeat emptyHeartbeat() {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParserTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParserTest.java
@@ -589,7 +589,8 @@ public class PipeHeartbeatParserTest {
   }
 
   private PipeHeartbeat createPipeHeartbeatWithCompletedRegions(
-      final PipeMeta pipeMeta, final boolean isCompleted, final List<Integer> completedRegionIds) {
+      final PipeMeta pipeMeta, final boolean isCompleted, final List<Integer> completedRegionIds)
+      throws Exception {
     return new PipeHeartbeat(
         Collections.singletonList(pipeMeta.serialize()),
         Collections.singletonList(isCompleted),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.agent.task;
 
+import org.apache.iotdb.common.rpc.thrift.TPipeCompletedDataRegion;
 import org.apache.iotdb.common.rpc.thrift.TPipeHeartbeatResp;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.concurrent.IoTThreadFactory;
@@ -501,7 +502,7 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
                 PipeConfig.getInstance().getPipeMetaReportMaxLogIntervalRounds(),
                 pipeMetaKeeper.getPipeMetaCount());
 
-    collectPipeMetaReport(logger, true).setTo(resp);
+    collectPipeMetaReport(logger).setTo(resp);
     PipeInsertionDataNodeListener.getInstance().listenToHeartbeat(true);
   }
 
@@ -523,17 +524,11 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
     LOGGER.debug(
         DataNodePipeMessages.RECEIVED_PIPE_HEARTBEAT_REQUEST_FROM_CONFIG_NODE, req.heartbeatId);
 
-    collectPipeMetaReport(logger, false).setTo(resp);
+    collectPipeMetaReport(logger).setTo(resp);
     PipeInsertionDataNodeListener.getInstance().listenToHeartbeat(true);
   }
 
-  private PipeMetaReport collectPipeMetaReport(
-      final Optional<Logger> logger, final boolean includeQueryMode) throws TException {
-    final Set<Integer> dataRegionIds =
-        StorageEngine.getInstance().getAllDataRegionIds().stream()
-            .map(DataRegionId::getId)
-            .collect(Collectors.toSet());
-
+  private PipeMetaReport collectPipeMetaReport(final Optional<Logger> logger) throws TException {
     final PipeMetaReport report = new PipeMetaReport();
     try {
       for (final PipeMeta pipeMeta : pipeMetaKeeper.getPipeMetaList()) {
@@ -543,14 +538,22 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
 
         final Map<Integer, PipeTask> pipeTaskMap = pipeTaskManager.getPipeTasks(staticMeta);
         final Set<Integer> expectedDataRegionIds = getExpectedDataRegionIds(pipeMeta);
-        final boolean isAllDataRegionCompleted =
-            isAllExpectedDataRegionCompleted(pipeTaskMap, expectedDataRegionIds);
-        final boolean isCompleted =
-            isAllDataRegionCompleted && includeDataAndNeedDrop(pipeMeta, includeQueryMode);
+        final List<Integer> completedDataRegionIds = new ArrayList<>();
+        if (pipeTaskMap != null) {
+          for (final Integer regionId : expectedDataRegionIds) {
+            final PipeTask pipeTask = pipeTaskMap.get(regionId);
+            if (pipeTask instanceof PipeDataNodeTask
+                && ((PipeDataNodeTask) pipeTask).isCompleted()) {
+              completedDataRegionIds.add(regionId);
+            }
+          }
+        }
+        report.pipeCompletedDataRegionList.add(
+            new TPipeCompletedDataRegion(
+                staticMeta.getPipeName(), staticMeta.getCreationTime(), completedDataRegionIds));
         final Pair<Long, Double> remainingEventAndTime =
             PipeDataNodeSinglePipeMetrics.getInstance()
                 .getRemainingEventAndTime(staticMeta.getPipeName(), staticMeta.getCreationTime());
-        report.pipeCompletedList.add(isCompleted);
         report.pipeRemainingEventCountList.add(remainingEventAndTime.getLeft());
         report.pipeRemainingTimeList.add(remainingEventAndTime.getRight());
         report.pipeDegradedStatusList.add(
@@ -559,16 +562,6 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
                     .getGlobalTsFileEpochDegraded()));
         report.pipeRecentFailureList.add(
             ((PipeTemporaryMetaInAgent) pipeMeta.getTemporaryMeta()).getRecentFailures());
-
-        logger.ifPresent(
-            l ->
-                PipeLogger.log(
-                    l::info,
-                    DataNodePipeMessages
-                        .LOG_REPORTING_PIPE_META_ARG_ISCOMPLETED_ARG_REMAININGEVENTCOUNT_ARG_8F996DF3,
-                    pipeMeta.coreReportMessage(),
-                    isCompleted,
-                    remainingEventAndTime.getLeft()));
       }
       logger.ifPresent(
           l ->
@@ -580,26 +573,6 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
       throw new TException(e);
     }
     return report;
-  }
-
-  // Returns whether every expected DataRegion has a completed local PipeTask on this DataNode.
-  // An empty expected set means this DataNode does not need to transfer history and is completed.
-  // A missing PipeTaskMap or a missing expected DataRegion means initialization failed.
-  static boolean isAllExpectedDataRegionCompleted(
-      final Map<Integer, PipeTask> pipeTaskMap, final Set<Integer> expectedDataRegionIds) {
-    if (expectedDataRegionIds.isEmpty()) {
-      // This DataNode does not own any target DataRegion for the pipe, so there is no local
-      // history transfer to wait for.
-      return true;
-    }
-    return pipeTaskMap != null
-        && expectedDataRegionIds.stream()
-            .allMatch(
-                dataRegionId -> {
-                  final PipeTask pipeTask = pipeTaskMap.get(dataRegionId);
-                  return pipeTask instanceof PipeDataNodeTask
-                      && ((PipeDataNodeTask) pipeTask).isCompleted();
-                });
   }
 
   // Returns the DataRegion ids that this DataNode is expected to transfer for the given pipe.
@@ -634,50 +607,30 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
     return expectedDataRegionIds;
   }
 
-  private boolean includeDataAndNeedDrop(final PipeMeta pipeMeta, final boolean includeQueryMode)
-      throws IllegalPathException {
-    final PipeParameters sourceParameters = pipeMeta.getStaticMeta().getSourceParameters();
-    if (!DataRegionListeningFilter.parseInsertionDeletionListeningOptionPair(sourceParameters)
-        .getLeft()) {
-      return false;
-    }
-    if (!includeQueryMode) {
-      return isSnapshotMode(sourceParameters);
-    }
-
-    final String sourceModeValue =
-        sourceParameters.getStringOrDefault(
-            Arrays.asList(
-                PipeSourceConstant.EXTRACTOR_MODE_KEY, PipeSourceConstant.SOURCE_MODE_KEY),
-            PipeSourceConstant.EXTRACTOR_MODE_DEFAULT_VALUE);
-    return sourceModeValue.equalsIgnoreCase(PipeSourceConstant.EXTRACTOR_MODE_QUERY_VALUE)
-        || sourceModeValue.equalsIgnoreCase(PipeSourceConstant.EXTRACTOR_MODE_SNAPSHOT_VALUE);
-  }
-
   private static class PipeMetaReport {
     private final List<ByteBuffer> pipeMetaBinaryList = new ArrayList<>();
-    private final List<Boolean> pipeCompletedList = new ArrayList<>();
     private final List<Long> pipeRemainingEventCountList = new ArrayList<>();
     private final List<Double> pipeRemainingTimeList = new ArrayList<>();
     private final List<Integer> pipeDegradedStatusList = new ArrayList<>();
     private final List<Map<String, Long>> pipeRecentFailureList = new ArrayList<>();
+    private final List<TPipeCompletedDataRegion> pipeCompletedDataRegionList = new ArrayList<>();
 
     private void setTo(final TDataNodeHeartbeatResp resp) {
       resp.setPipeMetaList(pipeMetaBinaryList);
-      resp.setPipeCompletedList(pipeCompletedList);
       resp.setPipeRemainingEventCountList(pipeRemainingEventCountList);
       resp.setPipeRemainingTimeList(pipeRemainingTimeList);
       resp.setPipeDegradedStatusList(pipeDegradedStatusList);
       resp.setPipeRecentFailureList(pipeRecentFailureList);
+      resp.setPipeCompletedDataRegionList(pipeCompletedDataRegionList);
     }
 
     private void setTo(final TPipeHeartbeatResp resp) {
       resp.setPipeMetaList(pipeMetaBinaryList);
-      resp.setPipeCompletedList(pipeCompletedList);
       resp.setPipeRemainingEventCountList(pipeRemainingEventCountList);
       resp.setPipeRemainingTimeList(pipeRemainingTimeList);
       resp.setPipeDegradedStatusList(pipeDegradedStatusList);
       resp.setPipeRecentFailureList(pipeRecentFailureList);
+      resp.setPipeCompletedDataRegionList(pipeCompletedDataRegionList);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -569,7 +569,7 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
                   l::info,
                   DataNodePipeMessages.LOG_REPORTED_ARG_PIPE_METAS_12068FC6,
                   report.pipeMetaBinaryList.size()));
-    } catch (final IOException | IllegalPathException e) {
+    } catch (final IOException e) {
       throw new TException(e);
     }
     return report;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -542,11 +542,9 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
         final PipeStaticMeta staticMeta = pipeMeta.getStaticMeta();
 
         final Map<Integer, PipeTask> pipeTaskMap = pipeTaskManager.getPipeTasks(staticMeta);
+        final Set<Integer> expectedDataRegionIds = getExpectedDataRegionIds(pipeMeta);
         final boolean isAllDataRegionCompleted =
-            pipeTaskMap == null
-                || pipeTaskMap.entrySet().stream()
-                    .filter(entry -> dataRegionIds.contains(entry.getKey()))
-                    .allMatch(entry -> ((PipeDataNodeTask) entry.getValue()).isCompleted());
+            isAllExpectedDataRegionCompleted(pipeTaskMap, expectedDataRegionIds);
         final boolean isCompleted =
             isAllDataRegionCompleted && includeDataAndNeedDrop(pipeMeta, includeQueryMode);
         final Pair<Long, Double> remainingEventAndTime =
@@ -582,6 +580,58 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
       throw new TException(e);
     }
     return report;
+  }
+
+  // Returns whether every expected DataRegion has a completed local PipeTask on this DataNode.
+  // An empty expected set means this DataNode does not need to transfer history and is completed.
+  // A missing PipeTaskMap or a missing expected DataRegion means initialization failed.
+  static boolean isAllExpectedDataRegionCompleted(
+      final Map<Integer, PipeTask> pipeTaskMap, final Set<Integer> expectedDataRegionIds) {
+    if (expectedDataRegionIds.isEmpty()) {
+      // This DataNode does not own any target DataRegion for the pipe, so there is no local
+      // history transfer to wait for.
+      return true;
+    }
+    return pipeTaskMap != null
+        && expectedDataRegionIds.stream()
+            .allMatch(
+                dataRegionId -> {
+                  final PipeTask pipeTask = pipeTaskMap.get(dataRegionId);
+                  return pipeTask instanceof PipeDataNodeTask
+                      && ((PipeDataNodeTask) pipeTask).isCompleted();
+                });
+  }
+
+  // Returns the DataRegion ids that this DataNode is expected to transfer for the given pipe.
+  // A region is included only when it is owned by this DataNode, is led by this DataNode according
+  // to the pipe's runtime metadata, and is selected by the pipe's source parameters. This expected
+  // set is used instead of the already-created PipeTask map so that a failed task initialization is
+  // not silently treated as a completed region.
+  private Set<Integer> getExpectedDataRegionIds(final PipeMeta pipeMeta) {
+    final PipeStaticMeta staticMeta = pipeMeta.getStaticMeta();
+    final PipeParameters sourceParameters = staticMeta.getSourceParameters();
+    final Set<Integer> localDataRegionIds =
+        StorageEngine.getInstance().getAllDataRegionIds().stream()
+            .map(DataRegionId::getId)
+            .collect(Collectors.toSet());
+    final Set<Integer> expectedDataRegionIds = new HashSet<>();
+    for (final Map.Entry<Integer, PipeTaskMeta> entry :
+        pipeMeta.getRuntimeMeta().getConsensusGroupId2TaskMetaMap().entrySet()) {
+      final int regionId = entry.getKey();
+      if (entry.getValue().getLeaderNodeId() != CONFIG.getDataNodeId()
+          || !localDataRegionIds.contains(regionId)) {
+        continue;
+      }
+      try {
+        if (DataRegionListeningFilter.shouldDataRegionBeListened(
+            sourceParameters, new DataRegionId(regionId), staticMeta.getPipeType())) {
+          expectedDataRegionIds.add(regionId);
+        }
+      } catch (final IllegalPathException e) {
+        throw new PipeException(e.toString());
+      }
+    }
+    return expectedDataRegionIds;
   }
 
   private boolean includeDataAndNeedDrop(final PipeMeta pipeMeta, final boolean includeQueryMode)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/util/ModsOperationUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/util/ModsOperationUtil.java
@@ -19,8 +19,10 @@
 
 package org.apache.iotdb.db.pipe.event.common.tsfile.parser.util;
 
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PatternTreeMap;
 import org.apache.iotdb.db.i18n.DataNodePipeMessages;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionPathUtils;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
 import org.apache.iotdb.db.utils.ModificationUtils;
@@ -90,7 +92,7 @@ public class ModsOperationUtil {
       return false;
     }
 
-    final List<ModEntry> mods = modifications.getOverlapped(deviceID, measurementID);
+    final List<ModEntry> mods = getOverlappedMods(deviceID, measurementID, modifications);
     if (mods == null || mods.isEmpty()) {
       return false;
     }
@@ -127,7 +129,7 @@ public class ModsOperationUtil {
     List<ModsInfo> modsInfos = new ArrayList<>(measurements.size());
 
     for (final String measurement : measurements) {
-      final List<ModEntry> mods = modifications.getOverlapped(deviceID, measurement);
+      final List<ModEntry> mods = getOverlappedMods(deviceID, measurement, modifications);
       if (mods == null || mods.isEmpty()) {
         // No mods, use empty list and index 0
         modsInfos.add(new ModsInfo(Collections.emptyList(), 0));
@@ -154,6 +156,17 @@ public class ModsOperationUtil {
     }
 
     return modsInfos;
+  }
+
+  private static List<ModEntry> getOverlappedMods(
+      final IDeviceID deviceID,
+      final String measurement,
+      final PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications) {
+    try {
+      return modifications.getOverlapped(CompactionPathUtils.getPath(deviceID, measurement));
+    } catch (final IllegalPathException e) {
+      throw new PipeException(e.getMessage(), e);
+    }
   }
 
   /**

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgentTest.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.SimpleProgressIndex;
+import org.apache.iotdb.commons.pipe.agent.task.PipeTask;
 import org.apache.iotdb.commons.pipe.agent.task.PipeTaskAgent;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMetaKeeper;
@@ -35,17 +36,62 @@ import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static org.mockito.Mockito.when;
 
 public class PipeDataNodeTaskAgentTest {
 
   private static final int LOCAL_NODE_ID = 1;
   private static final int REGION_ID = 7;
+
+  @Test
+  public void testIsAllExpectedDataRegionCompleted() {
+    final PipeDataNodeTask completedTask = Mockito.mock(PipeDataNodeTask.class);
+    when(completedTask.isCompleted()).thenReturn(true);
+    final PipeDataNodeTask uncompletedTask = Mockito.mock(PipeDataNodeTask.class);
+    when(uncompletedTask.isCompleted()).thenReturn(false);
+
+    final Map<Integer, PipeTask> pipeTaskMap = new HashMap<>();
+    pipeTaskMap.put(1, completedTask);
+    pipeTaskMap.put(2, completedTask);
+
+    final Set<Integer> completedExpectedRegionIds = new HashSet<>(Arrays.asList(1, 2));
+    Assert.assertTrue(
+        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
+            pipeTaskMap, completedExpectedRegionIds));
+
+    // A DataRegion that should be transferred is missing its local PipeTask.
+    final Set<Integer> partiallyMissingExpectedRegionIds = new HashSet<>(Arrays.asList(1, 2, 3));
+    Assert.assertFalse(
+        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
+            pipeTaskMap, partiallyMissingExpectedRegionIds));
+
+    // No local target DataRegion means this DataNode does not need to transfer history.
+    Assert.assertTrue(
+        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(null, Collections.emptySet()));
+
+    // A non-empty expected set with a missing PipeTaskMap means initialization failed.
+    Assert.assertFalse(
+        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
+            null, partiallyMissingExpectedRegionIds));
+
+    // An uncompleted PipeTask must not be reported as completed.
+    pipeTaskMap.put(3, uncompletedTask);
+    Assert.assertFalse(
+        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
+            pipeTaskMap, partiallyMissingExpectedRegionIds));
+  }
 
   @Test
   public void testGetPipeTaskProgressIndexReportsMissingTaskMeta() throws Exception {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgentTest.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.SimpleProgressIndex;
-import org.apache.iotdb.commons.pipe.agent.task.PipeTask;
 import org.apache.iotdb.commons.pipe.agent.task.PipeTaskAgent;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMetaKeeper;
@@ -36,62 +35,17 @@ import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import static org.mockito.Mockito.when;
 
 public class PipeDataNodeTaskAgentTest {
 
   private static final int LOCAL_NODE_ID = 1;
   private static final int REGION_ID = 7;
-
-  @Test
-  public void testIsAllExpectedDataRegionCompleted() {
-    final PipeDataNodeTask completedTask = Mockito.mock(PipeDataNodeTask.class);
-    when(completedTask.isCompleted()).thenReturn(true);
-    final PipeDataNodeTask uncompletedTask = Mockito.mock(PipeDataNodeTask.class);
-    when(uncompletedTask.isCompleted()).thenReturn(false);
-
-    final Map<Integer, PipeTask> pipeTaskMap = new HashMap<>();
-    pipeTaskMap.put(1, completedTask);
-    pipeTaskMap.put(2, completedTask);
-
-    final Set<Integer> completedExpectedRegionIds = new HashSet<>(Arrays.asList(1, 2));
-    Assert.assertTrue(
-        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
-            pipeTaskMap, completedExpectedRegionIds));
-
-    // A DataRegion that should be transferred is missing its local PipeTask.
-    final Set<Integer> partiallyMissingExpectedRegionIds = new HashSet<>(Arrays.asList(1, 2, 3));
-    Assert.assertFalse(
-        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
-            pipeTaskMap, partiallyMissingExpectedRegionIds));
-
-    // No local target DataRegion means this DataNode does not need to transfer history.
-    Assert.assertTrue(
-        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(null, Collections.emptySet()));
-
-    // A non-empty expected set with a missing PipeTaskMap means initialization failed.
-    Assert.assertFalse(
-        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
-            null, partiallyMissingExpectedRegionIds));
-
-    // An uncompleted PipeTask must not be reported as completed.
-    pipeTaskMap.put(3, uncompletedTask);
-    Assert.assertFalse(
-        PipeDataNodeTaskAgent.isAllExpectedDataRegionCompleted(
-            pipeTaskMap, partiallyMissingExpectedRegionIds));
-  }
 
   @Test
   public void testGetPipeTaskProgressIndexReportsMissingTaskMeta() throws Exception {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/meta/PipeTemporaryMetaInCoordinator.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/meta/PipeTemporaryMetaInCoordinator.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 public class PipeTemporaryMetaInCoordinator implements PipeTemporaryMeta {
 
   // ConfigNode statistics
-  private final Set<Integer> completedDataNodeIds =
+  private final Set<Integer> completedDataRegionIds =
       Collections.newSetFromMap(new ConcurrentHashMap<>());
   private final ConcurrentMap<Integer, Long> nodeId2RemainingEventMap = new ConcurrentHashMap<>();
   private final ConcurrentMap<Integer, Double> nodeId2RemainingTimeMap = new ConcurrentHashMap<>();
@@ -41,12 +41,12 @@ public class PipeTemporaryMetaInCoordinator implements PipeTemporaryMeta {
   private final ConcurrentMap<Integer, RecentFailureSnapshot> nodeId2RecentFailuresMap =
       new ConcurrentHashMap<>();
 
-  public void markDataNodeCompleted(final int dataNodeId) {
-    completedDataNodeIds.add(dataNodeId);
+  public void markDataRegionCompleted(final int dataRegionId) {
+    completedDataRegionIds.add(dataRegionId);
   }
 
-  public void markDataNodeUncompleted(final int dataNodeId) {
-    completedDataNodeIds.remove(dataNodeId);
+  public Set<Integer> getCompletedDataRegionIds() {
+    return completedDataRegionIds;
   }
 
   public void setRemainingEvent(final int dataNodeId, final long remainingEventCount) {
@@ -84,10 +84,6 @@ public class PipeTemporaryMetaInCoordinator implements PipeTemporaryMeta {
       nodeId2RecentFailuresMap.put(
           dataNodeId, new RecentFailureSnapshot(sanitizedFailures, System.currentTimeMillis()));
     }
-  }
-
-  public Set<Integer> getCompletedDataNodeIds() {
-    return completedDataNodeIds;
   }
 
   public long getGlobalRemainingEvents() {
@@ -131,7 +127,7 @@ public class PipeTemporaryMetaInCoordinator implements PipeTemporaryMeta {
       return false;
     }
     final PipeTemporaryMetaInCoordinator that = (PipeTemporaryMetaInCoordinator) o;
-    return Objects.equals(this.completedDataNodeIds, that.completedDataNodeIds)
+    return Objects.equals(this.completedDataRegionIds, that.completedDataRegionIds)
         && Objects.equals(this.nodeId2RemainingEventMap, that.nodeId2RemainingEventMap)
         && Objects.equals(this.nodeId2RemainingTimeMap, that.nodeId2RemainingTimeMap)
         && Objects.equals(this.nodeId2IsDegradedMap, that.nodeId2IsDegradedMap)
@@ -141,7 +137,7 @@ public class PipeTemporaryMetaInCoordinator implements PipeTemporaryMeta {
   @Override
   public int hashCode() {
     return Objects.hash(
-        completedDataNodeIds,
+        completedDataRegionIds,
         nodeId2RemainingEventMap,
         nodeId2RemainingTimeMap,
         nodeId2IsDegradedMap,
@@ -151,8 +147,8 @@ public class PipeTemporaryMetaInCoordinator implements PipeTemporaryMeta {
   @Override
   public String toString() {
     return "PipeTemporaryMeta{"
-        + "completedDataNodeIds="
-        + completedDataNodeIds
+        + "completedDataRegionIds="
+        + completedDataRegionIds
         + ", nodeId2RemainingEventMap="
         + nodeId2RemainingEventMap
         + ", nodeId2RemainingTimeMap="

--- a/iotdb-protocol/thrift-commons/src/main/thrift/common.thrift
+++ b/iotdb-protocol/thrift-commons/src/main/thrift/common.thrift
@@ -197,6 +197,12 @@ struct TSetThrottleQuotaReq {
   2: required TThrottleQuota throttleQuota
 }
 
+struct TPipeCompletedDataRegion {
+  1: required string pipeName
+  2: required i64 creationTime
+  3: required list<i32> completedDataRegionIds
+}
+
 struct TPipeHeartbeatResp {
   1: required list<binary> pipeMetaList
   2: optional list<bool> pipeCompletedList
@@ -204,6 +210,7 @@ struct TPipeHeartbeatResp {
   4: optional list<double> pipeRemainingTimeList
   5: optional list<i32> pipeDegradedStatusList
   6: optional list<map<string, i64>> pipeRecentFailureList
+  7: optional list<TPipeCompletedDataRegion> pipeCompletedDataRegionList
 }
 
 struct TLicense {

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
@@ -319,6 +319,7 @@ struct TDataNodeHeartbeatResp {
   17: optional map<i32, i64> dataRegionRawDataSize
   18: optional list<i32> pipeDegradedStatusList
   19: optional list<map<string, i64>> pipeRecentFailureList
+  20: optional list<common.TPipeCompletedDataRegion> pipeCompletedDataRegionList
 }
 
 struct TPipeHeartbeatReq {


### PR DESCRIPTION


## Problem

Snapshot/backup pipes can be automatically dropped even when some DataNodes failed to initialize their PipeConnector.

In the failing case, ConfigNode reported PIPE_PUSH_SINGLE_META failures with TSStatus(code:1807) and Broken pipe on multiple DataNodes, then PIPE_PUSH_ALL_META timed out. Some DataNodes therefore had no local PipeTask, but the old DataNode completion check treated a missing task map as completed. ConfigNode then saw every DataNode as completed and removed the pipe, making an incomplete backup look successful.

### Root cause

DataNode treated pipeTaskMap == null as all regions completed.

DataNode only checked existing tasks, so a Region whose PipeTask failed to start was silently ignored.

ConfigNode waited for all registered DataNodes instead of only the DataNodes that actually own target Regions for the pipe.

ConfigNode subtracted completed nodes from a live keySet() view, which could mutate the registered DataNode set.

### Changes

DataNode completion checkCompute the expected local DataRegion IDs from the pipe's runtime metadata. A DataNode is only reported completed when every expected local DataRegion has a completed PipeDataNodeTask. An empty expected set is treated as completed because that DataNode has no local history transfer to perform.

ConfigNode completion checkDerive the expected DataNode IDs from the pipe's runtime metadata instead of using all registered DataNodes. DataNodes that do not own any target Region are ignored during the auto-drop judgment. DataNodes that should participate but have not completed still block auto-drop.

Avoid mutating the registered DataNode setCopy the registered DataNode IDs before subtracting completed IDs, preventing removeAll from modifying the live keySet().

Add unit testAdd coverage for the DataNode completion predicate, including a missing expected Region, a missing task map, an uncompleted task, and an empty expected set.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
