### PR TITLE
Add ImportWAL tool with WAL replay controls

### DIFF
--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -82,8 +82,14 @@ public final class ImportWALMessages {
       "Table-model WAL entries require -db/--database.";
   public static final String EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0 =
       "Unsupported WAL operation: %s";
-  public static final String MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650 =
-      "Unsupported WAL operation: %s. Skip this entry? [y/N]: ";
+  public static final String
+      MESSAGE_TREE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_11E39FD7 =
+          "Tree-model delete operation detected: %s. Choose e=execute, s=skip, a=execute all, l=skip all, q=quit: ";
+  public static final String
+      MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_CHOOSE_S_SKIP_L_SKIP_ALL_Q_QUIT_0A734E52 =
+          "Unsupported WAL operation: %s. Choose s=skip, l=skip all, q=quit: ";
+  public static final String EXCEPTION_WAL_REPLAY_WAS_TERMINATED_BY_THE_USER_E0BD6197 =
+      "WAL replay was terminated by the user.";
   public static final String EXCEPTION_INSERT_NODE_ARG_CONTAINS_NO_REPLAYABLE_DATA_5DA13453 =
       "Insert node %s contains no replayable data.";
   public static final String EXCEPTION_UNSUPPORTED_SNAPSHOT_DATA_TYPE_ARG_7A32D312 =

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.i18n;
+
+/** Compile-time i18n constants for the WAL import tool (English). */
+public final class ImportWALMessages {
+
+  public static final String MESSAGE_IMPORT_WAL_5E42804E = "import-wal";
+  public static final String
+      MESSAGE_PATH_OF_A_WAL_FILE_OR_A_DIRECTORY_CONTAINING_WAL_FILES_473D0554 =
+      "Path of a WAL file or a directory containing WAL files.";
+  public static final String MESSAGE_TARGET_IOTDB_HOST_DEFAULT_127_0_0_1_3729156F =
+      "Target IoTDB host. Default: 127.0.0.1.";
+  public static final String MESSAGE_TARGET_IOTDB_RPC_PORT_DEFAULT_6667_FC0D345D =
+      "Target IoTDB RPC port. Default: 6667.";
+  public static final String MESSAGE_TARGET_IOTDB_USERNAME_DEFAULT_ROOT_EB91453B =
+      "Target IoTDB username. Default: root.";
+  public static final String
+      MESSAGE_TARGET_IOTDB_PASSWORD_PROMPTED_INTERACTIVELY_IF_OMITTED_29681961 =
+      "Target IoTDB password. Prompted interactively if omitted.";
+  public static final String MESSAGE_PASSWORD_PROMPT_F2D0E794 = "Password: ";
+  public static final String MESSAGE_TARGET_DATABASE_FOR_TABLE_MODEL_WAL_ENTRIES_27BACD1C =
+      "Target database for table-model WAL entries.";
+  public static final String MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A =
+      "Print this help message.";
+  public static final String MESSAGE_ARGUMENT_ERROR_ARG_A9767F62 = "Argument error: %s";
+  public static final String MESSAGE_WAL_IMPORT_FAILED_ARG_55C014BA = "WAL import failed: %s";
+  public static final String EXCEPTION_SOURCE_PATH_DOES_NOT_EXIST_ARG_7C806CA2 =
+      "Source path does not exist: %s";
+  public static final String EXCEPTION_SOURCE_FILE_IS_NOT_A_WAL_FILE_ARG_14A43F76 =
+      "Source file is not a WAL file: %s";
+  public static final String EXCEPTION_NO_WAL_FILES_FOUND_UNDER_ARG_45F7FA22 =
+      "No WAL files found under: %s";
+  public static final String EXCEPTION_INVALID_PORT_ARG_A7CDD5AC = "Invalid port: %s";
+  public static final String
+      MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A =
+          "Replayed %d operations from %d WAL files; skipped %d entries.";
+  public static final String
+      MESSAGE_PROGRESS_ARG_COMPLETED_FILES_ARG_TOTAL_FILES_ARG_PROCESSED_BYTES_ARG_TOTAL_BYTES_ARG_PERCENT_ARG_ELAPSED_SECONDS_ARG_RATE_ARG_MB_PER_SECOND_F1C1356F =
+          "Progress: %d/%d WAL files completed, %d/%d bytes (%.1f%%), elapsed %.1f s, rate %.1f MB/s.";
+  public static final String
+      MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D =
+          "Import duration: %.1f s; total size: %d bytes; average rate: %.1f MB/s.";
+  public static final String EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9 =
+      "Failed to replay WAL file %s at offset %d: %s";
+  public static final String EXCEPTION_TABLE_MODEL_WAL_ENTRIES_REQUIRE_DB_DATABASE_F7597726 =
+      "Table-model WAL entries require -db/--database.";
+  public static final String EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0 =
+      "Unsupported WAL operation: %s";
+  public static final String MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650 =
+      "Unsupported WAL operation: %s. Skip this entry? [y/N]: ";
+  public static final String EXCEPTION_INSERT_NODE_ARG_CONTAINS_NO_REPLAYABLE_DATA_5DA13453 =
+      "Insert node %s contains no replayable data.";
+  public static final String EXCEPTION_UNSUPPORTED_SNAPSHOT_DATA_TYPE_ARG_7A32D312 =
+      "Unsupported snapshot data type: %s";
+  public static final String EXCEPTION_THE_WAL_FILE_IS_TRUNCATED_OR_CORRUPTED_6B0734C5 =
+      "The WAL file is truncated or corrupted.";
+  public static final String
+      EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD =
+          "Password was not provided and interactive input is unavailable. Specify -pw/--password.";
+
+  private ImportWALMessages() {}
+}

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -38,6 +38,9 @@ public final class ImportWALMessages {
   public static final String MESSAGE_PASSWORD_PROMPT_F2D0E794 = "Password: ";
   public static final String MESSAGE_TARGET_DATABASE_FOR_TABLE_MODEL_WAL_ENTRIES_27BACD1C =
       "Target database for table-model WAL entries.";
+  public static final String
+      MESSAGE_WHEN_ALL_WAL_FILES_ARE_REPLAYED_SUCCESSFULLY_DO_OPERATION_ON_SOURCE_WAL_FILES_OPTIONAL_PARAMETERS_ARE_NONE_DEFAULT_AND_DELETE_41963A66 =
+          "When all WAL files are replayed successfully, do operation on source WAL files. Optional parameters are none (default) and delete.";
   public static final String MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A =
       "Print this help message.";
   public static final String MESSAGE_ARGUMENT_ERROR_ARG_A9767F62 = "Argument error: %s";
@@ -58,8 +61,15 @@ public final class ImportWALMessages {
   public static final String
       MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D =
           "Import duration: %.1f s; total size: %d bytes; average rate: %.1f MB/s.";
+  public static final String MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B =
+      "Deleted %d source WAL files.";
   public static final String EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9 =
       "Failed to replay WAL file %s at offset %d: %s";
+  public static final String EXCEPTION_FAILED_TO_DELETE_SOURCE_WAL_FILE_ARG_ARG_236AF580 =
+      "Failed to delete source WAL file %s: %s";
+  public static final String
+      EXCEPTION_UNSUPPORTED_ON_SUCCESS_VALUE_ARG_EXPECTED_NONE_OR_DELETE_F1C8EACE =
+          "Unsupported on_success value: %s. Expected none or delete.";
   public static final String EXCEPTION_TABLE_MODEL_WAL_ENTRIES_REQUIRE_DB_DATABASE_F7597726 =
       "Table-model WAL entries require -db/--database.";
   public static final String EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0 =

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -41,6 +41,9 @@ public final class ImportWALMessages {
   public static final String
       MESSAGE_WHEN_ALL_WAL_FILES_ARE_REPLAYED_SUCCESSFULLY_DO_OPERATION_ON_SOURCE_WAL_FILES_OPTIONAL_PARAMETERS_ARE_NONE_DEFAULT_AND_DELETE_41963A66 =
           "When all WAL files are replayed successfully, do operation on source WAL files. Optional parameters are none (default) and delete.";
+  public static final String
+      MESSAGE_NUMBER_OF_THREADS_USED_TO_REPLAY_WAL_DIRECTORIES_IN_PARALLEL_DEFAULT_1_6AEF4F50 =
+          "Number of threads used to replay WAL directories in parallel. Default: 1.";
   public static final String MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A =
       "Print this help message.";
   public static final String MESSAGE_ARGUMENT_ERROR_ARG_A9767F62 = "Argument error: %s";
@@ -52,6 +55,11 @@ public final class ImportWALMessages {
   public static final String EXCEPTION_NO_WAL_FILES_FOUND_UNDER_ARG_45F7FA22 =
       "No WAL files found under: %s";
   public static final String EXCEPTION_INVALID_PORT_ARG_A7CDD5AC = "Invalid port: %s";
+  public static final String
+      EXCEPTION_INVALID_THREAD_COUNT_ARG_EXPECTED_A_POSITIVE_INTEGER_F3AE2CFD =
+          "Invalid thread count: %s. Expected a positive integer.";
+  public static final String EXCEPTION_WAL_REPLAY_WAS_INTERRUPTED_770BA8AD =
+      "WAL replay was interrupted.";
   public static final String
       MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A =
           "Replayed %d operations from %d WAL files; skipped %d entries.";

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -100,5 +100,23 @@ public final class ImportWALMessages {
       EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD =
           "Password was not provided and interactive input is unavailable. Specify -pw/--password.";
 
+  public static final String MESSAGE_TABLE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_0C8D178A =
+      "Table-model delete operation detected: %s. Choose e=execute, s=skip, a=execute all, l=skip all, q=quit: ";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_COLUMN_SPECIFIC_DELETION_FOR_TABLE_ARG_AS_DELETE_FROM_4A7ACC93 =
+      "Cannot replay column-specific deletion for table %s as DELETE FROM.";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TARGET_TABLE_ARG_HAS_NO_TIME_COLUMN_55B1C25C =
+      "Cannot replay table deletion: target table %s has no TIME column.";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TAG_SEGMENT_INDEX_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_D5E3CCEE =
+      "Cannot replay table deletion: TAG segment index %d is incompatible with target table %s.";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_DEVICE_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_A6320535 =
+      "Cannot replay table deletion: device %s is incompatible with target table %s.";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_UNSUPPORTED_TAG_PREDICATE_ARG_AD0753A8 =
+      "Cannot replay table deletion: unsupported TAG predicate %s.";
+
   private ImportWALMessages() {}
 }

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -38,6 +38,9 @@ public final class ImportWALMessages {
   public static final String MESSAGE_PASSWORD_PROMPT_F2D0E794 = "密码：";
   public static final String MESSAGE_TARGET_DATABASE_FOR_TABLE_MODEL_WAL_ENTRIES_27BACD1C =
       "表模型 WAL 条目的目标数据库。";
+  public static final String
+      MESSAGE_WHEN_ALL_WAL_FILES_ARE_REPLAYED_SUCCESSFULLY_DO_OPERATION_ON_SOURCE_WAL_FILES_OPTIONAL_PARAMETERS_ARE_NONE_DEFAULT_AND_DELETE_41963A66 =
+          "所有 WAL 文件成功重放后，对源 WAL 文件执行操作。可选参数为 none（默认）和 delete。";
   public static final String MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A = "打印帮助信息。";
   public static final String MESSAGE_ARGUMENT_ERROR_ARG_A9767F62 = "参数错误：%s";
   public static final String MESSAGE_WAL_IMPORT_FAILED_ARG_55C014BA = "WAL 导入失败：%s";
@@ -57,8 +60,15 @@ public final class ImportWALMessages {
   public static final String
       MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D =
           "导入耗时：%.1f 秒；文件总大小：%d 字节；平均速率：%.1f MB/s。";
+  public static final String MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B =
+      "已删除 %d 个源 WAL 文件。";
   public static final String EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9 =
       "重放 WAL 文件 %s 时失败，偏移量 %d：%s";
+  public static final String EXCEPTION_FAILED_TO_DELETE_SOURCE_WAL_FILE_ARG_ARG_236AF580 =
+      "删除源 WAL 文件 %s 失败：%s";
+  public static final String
+      EXCEPTION_UNSUPPORTED_ON_SUCCESS_VALUE_ARG_EXPECTED_NONE_OR_DELETE_F1C8EACE =
+          "不支持的 on_success 值：%s。应为 none 或 delete。";
   public static final String EXCEPTION_TABLE_MODEL_WAL_ENTRIES_REQUIRE_DB_DATABASE_F7597726 =
       "表模型 WAL 条目要求指定 -db/--database。";
   public static final String EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0 =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -41,6 +41,9 @@ public final class ImportWALMessages {
   public static final String
       MESSAGE_WHEN_ALL_WAL_FILES_ARE_REPLAYED_SUCCESSFULLY_DO_OPERATION_ON_SOURCE_WAL_FILES_OPTIONAL_PARAMETERS_ARE_NONE_DEFAULT_AND_DELETE_41963A66 =
           "所有 WAL 文件成功重放后，对源 WAL 文件执行操作。可选参数为 none（默认）和 delete。";
+  public static final String
+      MESSAGE_NUMBER_OF_THREADS_USED_TO_REPLAY_WAL_DIRECTORIES_IN_PARALLEL_DEFAULT_1_6AEF4F50 =
+          "并行重放 WAL 目录所用的线程数。默认：1。";
   public static final String MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A = "打印帮助信息。";
   public static final String MESSAGE_ARGUMENT_ERROR_ARG_A9767F62 = "参数错误：%s";
   public static final String MESSAGE_WAL_IMPORT_FAILED_ARG_55C014BA = "WAL 导入失败：%s";
@@ -51,6 +54,11 @@ public final class ImportWALMessages {
   public static final String EXCEPTION_NO_WAL_FILES_FOUND_UNDER_ARG_45F7FA22 =
       "路径下未找到 WAL 文件：%s";
   public static final String EXCEPTION_INVALID_PORT_ARG_A7CDD5AC = "无效端口：%s";
+  public static final String
+      EXCEPTION_INVALID_THREAD_COUNT_ARG_EXPECTED_A_POSITIVE_INTEGER_F3AE2CFD =
+          "无效线程数：%s。应为正整数。";
+  public static final String EXCEPTION_WAL_REPLAY_WAS_INTERRUPTED_770BA8AD =
+      "WAL 重放被中断。";
   public static final String
       MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A =
           "已重放 %d 个操作（来自 %d 个 WAL 文件）；跳过 %d 个条目。";

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -81,8 +81,14 @@ public final class ImportWALMessages {
       "表模型 WAL 条目要求指定 -db/--database。";
   public static final String EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0 =
       "不支持的 WAL 操作：%s";
-  public static final String MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650 =
-      "不支持的 WAL 操作：%s。是否跳过此条目？[y/N]：";
+  public static final String
+      MESSAGE_TREE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_11E39FD7 =
+          "检测到树模型删除操作：%s。请选择 e=执行、s=跳过、a=全部执行、l=全部跳过、q=终止重放：";
+  public static final String
+      MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_CHOOSE_S_SKIP_L_SKIP_ALL_Q_QUIT_0A734E52 =
+          "不支持的 WAL 操作：%s。请选择 s=跳过、l=全部跳过、q=终止重放：";
+  public static final String EXCEPTION_WAL_REPLAY_WAS_TERMINATED_BY_THE_USER_E0BD6197 =
+      "用户终止了 WAL 重放。";
   public static final String EXCEPTION_INSERT_NODE_ARG_CONTAINS_NO_REPLAYABLE_DATA_5DA13453 =
       "Insert node %s 不包含可重放数据。";
   public static final String EXCEPTION_UNSUPPORTED_SNAPSHOT_DATA_TYPE_ARG_7A32D312 =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.i18n;
+
+/** WAL 导入工具的编译期国际化常量（中文）。 */
+public final class ImportWALMessages {
+
+  public static final String MESSAGE_IMPORT_WAL_5E42804E = "import-wal";
+  public static final String
+      MESSAGE_PATH_OF_A_WAL_FILE_OR_A_DIRECTORY_CONTAINING_WAL_FILES_473D0554 =
+          "WAL 文件或包含 WAL 文件的目录路径。";
+  public static final String MESSAGE_TARGET_IOTDB_HOST_DEFAULT_127_0_0_1_3729156F =
+      "目标 IoTDB 主机。默认：127.0.0.1。";
+  public static final String MESSAGE_TARGET_IOTDB_RPC_PORT_DEFAULT_6667_FC0D345D =
+      "目标 IoTDB RPC 端口。默认：6667。";
+  public static final String MESSAGE_TARGET_IOTDB_USERNAME_DEFAULT_ROOT_EB91453B =
+      "目标 IoTDB 用户名。默认：root。";
+  public static final String
+      MESSAGE_TARGET_IOTDB_PASSWORD_PROMPTED_INTERACTIVELY_IF_OMITTED_29681961 =
+      "目标 IoTDB 密码。未提供时将交互式询问。";
+  public static final String MESSAGE_PASSWORD_PROMPT_F2D0E794 = "密码：";
+  public static final String MESSAGE_TARGET_DATABASE_FOR_TABLE_MODEL_WAL_ENTRIES_27BACD1C =
+      "表模型 WAL 条目的目标数据库。";
+  public static final String MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A = "打印帮助信息。";
+  public static final String MESSAGE_ARGUMENT_ERROR_ARG_A9767F62 = "参数错误：%s";
+  public static final String MESSAGE_WAL_IMPORT_FAILED_ARG_55C014BA = "WAL 导入失败：%s";
+  public static final String EXCEPTION_SOURCE_PATH_DOES_NOT_EXIST_ARG_7C806CA2 =
+      "源路径不存在：%s";
+  public static final String EXCEPTION_SOURCE_FILE_IS_NOT_A_WAL_FILE_ARG_14A43F76 =
+      "源文件不是 WAL 文件：%s";
+  public static final String EXCEPTION_NO_WAL_FILES_FOUND_UNDER_ARG_45F7FA22 =
+      "路径下未找到 WAL 文件：%s";
+  public static final String EXCEPTION_INVALID_PORT_ARG_A7CDD5AC = "无效端口：%s";
+  public static final String
+      MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A =
+          "已重放 %d 个操作（来自 %d 个 WAL 文件）；跳过 %d 个条目。";
+  public static final String
+      MESSAGE_PROGRESS_ARG_COMPLETED_FILES_ARG_TOTAL_FILES_ARG_PROCESSED_BYTES_ARG_TOTAL_BYTES_ARG_PERCENT_ARG_ELAPSED_SECONDS_ARG_RATE_ARG_MB_PER_SECOND_F1C1356F =
+          "进度：已完成 %d/%d 个 WAL 文件，已处理 %d/%d 字节（%.1f%%），耗时 %.1f 秒，速率 %.1f MB/s。";
+  public static final String
+      MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D =
+          "导入耗时：%.1f 秒；文件总大小：%d 字节；平均速率：%.1f MB/s。";
+  public static final String EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9 =
+      "重放 WAL 文件 %s 时失败，偏移量 %d：%s";
+  public static final String EXCEPTION_TABLE_MODEL_WAL_ENTRIES_REQUIRE_DB_DATABASE_F7597726 =
+      "表模型 WAL 条目要求指定 -db/--database。";
+  public static final String EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0 =
+      "不支持的 WAL 操作：%s";
+  public static final String MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650 =
+      "不支持的 WAL 操作：%s。是否跳过此条目？[y/N]：";
+  public static final String EXCEPTION_INSERT_NODE_ARG_CONTAINS_NO_REPLAYABLE_DATA_5DA13453 =
+      "Insert node %s 不包含可重放数据。";
+  public static final String EXCEPTION_UNSUPPORTED_SNAPSHOT_DATA_TYPE_ARG_7A32D312 =
+      "Unsupported snapshot data type: %s";
+  public static final String EXCEPTION_THE_WAL_FILE_IS_TRUNCATED_OR_CORRUPTED_6B0734C5 =
+      "WAL 文件被截断或已损坏。";
+  public static final String
+      EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD =
+          "未提供密码且当前环境不支持交互式输入，请指定 -pw/--password。";
+
+  private ImportWALMessages() {}
+}

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/ImportWALMessages.java
@@ -99,5 +99,23 @@ public final class ImportWALMessages {
       EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD =
           "未提供密码且当前环境不支持交互式输入，请指定 -pw/--password。";
 
+  public static final String MESSAGE_TABLE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_0C8D178A =
+      "检测到表模型删除操作：%s。请选择 e=执行、s=跳过、a=全部执行、l=全部跳过、q=退出：";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_COLUMN_SPECIFIC_DELETION_FOR_TABLE_ARG_AS_DELETE_FROM_4A7ACC93 =
+      "无法将表 %s 的指定列删除重放为 DELETE FROM。";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TARGET_TABLE_ARG_HAS_NO_TIME_COLUMN_55B1C25C =
+      "无法重放表模型删除：目标表 %s 没有 TIME 列。";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TAG_SEGMENT_INDEX_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_D5E3CCEE =
+      "无法重放表模型删除：TAG 段索引 %d 与目标表 %s 不兼容。";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_DEVICE_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_A6320535 =
+      "无法重放表模型删除：设备 %s 与目标表 %s 不兼容。";
+
+  public static final String EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_UNSUPPORTED_TAG_PREDICATE_ARG_AD0753A8 =
+      "无法重放表模型删除：不支持 TAG 条件 %s。";
+
   private ImportWALMessages() {}
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/TagPredicate.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/TagPredicate.java
@@ -201,6 +201,10 @@ public abstract class TagPredicate implements StreamSerializable, BufferSerializ
       super(TagPredicateType.FULL_EXACT_MATCH);
     }
 
+    public IDeviceID getDeviceID() {
+      return deviceID;
+    }
+
     @Override
     public int serializedSize() {
       return super.serializedSize() + deviceID.serializedSize();
@@ -278,6 +282,14 @@ public abstract class TagPredicate implements StreamSerializable, BufferSerializ
 
     public SegmentExactMatch() {
       super(TagPredicateType.SEGMENT_EXACT_MATCH);
+    }
+
+    public String getPattern() {
+      return pattern;
+    }
+
+    public int getSegmentIndex() {
+      return segmentIndex;
     }
 
     @Override
@@ -366,6 +378,10 @@ public abstract class TagPredicate implements StreamSerializable, BufferSerializ
 
     public DeviceIn() {
       super(TagPredicateType.DEVICE_IN);
+    }
+
+    public Set<IDeviceID> getDeviceIDs() {
+      return Collections.unmodifiableSet(deviceIDs);
     }
 
     @Override
@@ -462,6 +478,10 @@ public abstract class TagPredicate implements StreamSerializable, BufferSerializ
       super(TagPredicateType.SEGMENT_NOT_NULL);
     }
 
+    public int getSegmentIndex() {
+      return segmentIndex;
+    }
+
     @Override
     public int serializedSize() {
       return super.serializedSize() + ReadWriteForEncodingUtils.varIntSize(segmentIndex);
@@ -536,6 +556,10 @@ public abstract class TagPredicate implements StreamSerializable, BufferSerializ
 
     public void add(TagPredicate predicate) {
       predicates.add(predicate);
+    }
+
+    public List<TagPredicate> getPredicates() {
+      return Collections.unmodifiableList(predicates);
     }
 
     @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALReader.java
@@ -72,6 +72,11 @@ public class WALReader implements Closeable {
       return false;
     }
     try {
+      // An active WAL has no end marker until its writer closes. Reaching EOF exactly between
+      // entries is therefore valid, while EOF during deserialization still marks a partial entry.
+      if (walInputStream.available() == 0) {
+        return false;
+      }
       nextEntry = WALEntry.deserialize(logStream);
       if (nextEntry.getType() == WALEntryType.WAL_FILE_INFO_END_MARKER) {
         nextEntry = null;
@@ -96,6 +101,10 @@ public class WALReader implements Closeable {
 
   public long getWALCurrentReadOffset() throws IOException {
     return walInputStream.getFileCurrentPos();
+  }
+
+  public boolean isFileCorrupted() {
+    return fileCorrupted;
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
@@ -118,6 +118,8 @@ public class ImportWAL {
       final Path source = Paths.get(commandLine.getOptionValue("file"));
       final List<Path> walFiles = collectWALFiles(source);
       final String database = commandLine.getOptionValue("database");
+      final boolean deleteSource =
+          shouldDeleteSource(commandLine.getOptionValue("on_success", "none"));
       final String password = getPassword(commandLine);
       final Session treeSession =
           createSession(
@@ -141,7 +143,8 @@ public class ImportWAL {
           tableSession.open(false);
         }
         final ReplayStatistics statistics =
-            replayWALFiles(walFiles, new WALReplayer(treeSession, tableSession, database), out);
+            replayWALFiles(
+                walFiles, new WALReplayer(treeSession, tableSession, database), out, deleteSource);
         out.printf(
             ImportWALMessages
                 .MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A,
@@ -156,6 +159,11 @@ public class ImportWAL {
             statistics.getTotalBytes(),
             statistics.getAverageRateMbPerSecond());
         out.println();
+        if (deleteSource) {
+          out.printf(
+              ImportWALMessages.MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B, walFiles.size());
+          out.println();
+        }
       } finally {
         closeSession(tableSession);
         closeSession(treeSession);
@@ -212,6 +220,15 @@ public class ImportWAL {
             .desc(ImportWALMessages.MESSAGE_TARGET_DATABASE_FOR_TABLE_MODEL_WAL_ENTRIES_27BACD1C)
             .build());
     options.addOption(
+        Option.builder("os")
+            .longOpt("on_success")
+            .argName("on_success")
+            .hasArg()
+            .desc(
+                ImportWALMessages
+                    .MESSAGE_WHEN_ALL_WAL_FILES_ARE_REPLAYED_SUCCESSFULLY_DO_OPERATION_ON_SOURCE_WAL_FILES_OPTIONAL_PARAMETERS_ARE_NONE_DEFAULT_AND_DELETE_41963A66)
+            .build());
+    options.addOption(
         Option.builder()
             .longOpt("help")
             .desc(ImportWALMessages.MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A)
@@ -240,6 +257,21 @@ public class ImportWAL {
               .EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD);
     }
     return new String(password);
+  }
+
+  static boolean shouldDeleteSource(final String onSuccess) {
+    final String normalizedOnSuccess = onSuccess.trim();
+    if ("none".equalsIgnoreCase(normalizedOnSuccess)) {
+      return false;
+    }
+    if ("delete".equalsIgnoreCase(normalizedOnSuccess)) {
+      return true;
+    }
+    throw new IllegalArgumentException(
+        String.format(
+            ImportWALMessages
+                .EXCEPTION_UNSUPPORTED_ON_SUCCESS_VALUE_ARG_EXPECTED_NONE_OR_DELETE_F1C8EACE,
+            onSuccess));
   }
 
   private static boolean containsHelpOption(final String[] args) {
@@ -368,6 +400,15 @@ public class ImportWAL {
   static ReplayStatistics replayWALFiles(
       final List<Path> walFiles, final WALReplayer replayer, final PrintStream progressStream)
       throws IOException {
+    return replayWALFiles(walFiles, replayer, progressStream, false);
+  }
+
+  static ReplayStatistics replayWALFiles(
+      final List<Path> walFiles,
+      final WALReplayer replayer,
+      final PrintStream progressStream,
+      final boolean deleteSource)
+      throws IOException {
     final ReplayStatistics statistics = new ReplayStatistics();
     final long startNanos = System.nanoTime();
     for (final Path walFile : walFiles) {
@@ -436,7 +477,25 @@ public class ImportWAL {
             e);
       }
     }
+    if (deleteSource) {
+      deleteSourceWALFiles(walFiles);
+    }
     return statistics;
+  }
+
+  private static void deleteSourceWALFiles(final List<Path> walFiles) throws IOException {
+    for (final Path walFile : walFiles) {
+      try {
+        Files.delete(walFile);
+      } catch (final IOException e) {
+        throw new IOException(
+            String.format(
+                ImportWALMessages.EXCEPTION_FAILED_TO_DELETE_SOURCE_WAL_FILE_ARG_ARG_236AF580,
+                walFile,
+                e.getMessage()),
+            e);
+      }
+    }
   }
 
   static class WALReplayer {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
@@ -75,10 +75,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -89,7 +96,9 @@ public class ImportWAL {
   private static final String DEFAULT_HOST = "127.0.0.1";
   private static final int DEFAULT_PORT = 6667;
   private static final String DEFAULT_USER = "root";
+  private static final int DEFAULT_THREAD_NUM = 1;
   private static final int SNAPSHOT_TABLET_ROW_LIMIT = 1024;
+  private static final Object CONSOLE_PROMPT_LOCK = new Object();
 
   private ImportWAL() {}
 
@@ -120,53 +129,38 @@ public class ImportWAL {
       final String database = commandLine.getOptionValue("database");
       final boolean deleteSource =
           shouldDeleteSource(commandLine.getOptionValue("on_success", "none"));
+      final int threadNum =
+          parseThreadNum(
+              commandLine.getOptionValue("thread_num", String.valueOf(DEFAULT_THREAD_NUM)));
       final String password = getPassword(commandLine);
-      final Session treeSession =
-          createSession(
-              commandLine.getOptionValue("host", DEFAULT_HOST),
-              parsePort(commandLine.getOptionValue("port", String.valueOf(DEFAULT_PORT))),
-              commandLine.getOptionValue("username", DEFAULT_USER),
-              password,
-              null);
-      final Session tableSession =
-          database == null
-              ? null
-              : createSession(
-                  commandLine.getOptionValue("host", DEFAULT_HOST),
-                  parsePort(commandLine.getOptionValue("port", String.valueOf(DEFAULT_PORT))),
-                  commandLine.getOptionValue("username", DEFAULT_USER),
-                  password,
-                  database);
-      try {
-        treeSession.open(false);
-        if (tableSession != null) {
-          tableSession.open(false);
-        }
-        final ReplayStatistics statistics =
-            replayWALFiles(
-                walFiles, new WALReplayer(treeSession, tableSession, database), out, deleteSource);
+      final String host = commandLine.getOptionValue("host", DEFAULT_HOST);
+      final int port = parsePort(commandLine.getOptionValue("port", String.valueOf(DEFAULT_PORT)));
+      final String username = commandLine.getOptionValue("username", DEFAULT_USER);
+      final ReplayStatistics statistics =
+          replayWALDirectories(
+              walFiles,
+              threadNum,
+              () -> createWALReplayWorker(host, port, username, password, database),
+              out,
+              deleteSource);
+      out.printf(
+          ImportWALMessages
+              .MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A,
+          statistics.replayedOperationCount,
+          walFiles.size(),
+          statistics.skippedEntryCount);
+      out.println();
+      out.printf(
+          ImportWALMessages
+              .MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D,
+          statistics.getElapsedSeconds(),
+          statistics.getTotalBytes(),
+          statistics.getAverageRateMbPerSecond());
+      out.println();
+      if (deleteSource) {
         out.printf(
-            ImportWALMessages
-                .MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A,
-            statistics.replayedOperationCount,
-            walFiles.size(),
-            statistics.skippedEntryCount);
+            ImportWALMessages.MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B, walFiles.size());
         out.println();
-        out.printf(
-            ImportWALMessages
-                .MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D,
-            statistics.getElapsedSeconds(),
-            statistics.getTotalBytes(),
-            statistics.getAverageRateMbPerSecond());
-        out.println();
-        if (deleteSource) {
-          out.printf(
-              ImportWALMessages.MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B, walFiles.size());
-          out.println();
-        }
-      } finally {
-        closeSession(tableSession);
-        closeSession(treeSession);
       }
       return CODE_OK;
     } catch (final Exception e) {
@@ -227,6 +221,15 @@ public class ImportWAL {
             .desc(
                 ImportWALMessages
                     .MESSAGE_WHEN_ALL_WAL_FILES_ARE_REPLAYED_SUCCESSFULLY_DO_OPERATION_ON_SOURCE_WAL_FILES_OPTIONAL_PARAMETERS_ARE_NONE_DEFAULT_AND_DELETE_41963A66)
+            .build());
+    options.addOption(
+        Option.builder("tn")
+            .longOpt("thread_num")
+            .argName("thread_num")
+            .hasArg()
+            .desc(
+                ImportWALMessages
+                    .MESSAGE_NUMBER_OF_THREADS_USED_TO_REPLAY_WAL_DIRECTORIES_IN_PARALLEL_DEFAULT_1_6AEF4F50)
             .build());
     options.addOption(
         Option.builder()
@@ -314,6 +317,23 @@ public class ImportWAL {
     }
   }
 
+  static int parseThreadNum(final String threadNum) {
+    try {
+      final int value = Integer.parseInt(threadNum);
+      if (value <= 0) {
+        throw new NumberFormatException(threadNum);
+      }
+      return value;
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              ImportWALMessages
+                  .EXCEPTION_INVALID_THREAD_COUNT_ARG_EXPECTED_A_POSITIVE_INTEGER_F3AE2CFD,
+              threadNum),
+          e);
+    }
+  }
+
   private static Session createSession(
       final String host,
       final int port,
@@ -326,6 +346,29 @@ public class ImportWAL {
       builder.sqlDialect("table").database(database);
     }
     return builder.build();
+  }
+
+  private static WALReplayWorker createWALReplayWorker(
+      final String host,
+      final int port,
+      final String username,
+      final String password,
+      final String database)
+      throws IOException {
+    final Session treeSession = createSession(host, port, username, password, null);
+    final Session tableSession =
+        database == null ? null : createSession(host, port, username, password, database);
+    try {
+      treeSession.open(false);
+      if (tableSession != null) {
+        tableSession.open(false);
+      }
+      return new SessionWALReplayer(treeSession, tableSession, database);
+    } catch (final IoTDBConnectionException e) {
+      closeSession(tableSession);
+      closeSession(treeSession);
+      throw new IOException(e.getMessage(), e);
+    }
   }
 
   private static void closeSession(final Session session) {
@@ -409,78 +452,219 @@ public class ImportWAL {
       final PrintStream progressStream,
       final boolean deleteSource)
       throws IOException {
-    final ReplayStatistics statistics = new ReplayStatistics();
     final long startNanos = System.nanoTime();
+    final ReplayStatistics statistics = createReplayStatistics(walFiles);
     for (final Path walFile : walFiles) {
-      statistics.totalBytes += Files.size(walFile);
-    }
-    for (final Path walFile : walFiles) {
-      try (WALReader reader = new WALReader(walFile.toFile())) {
-        long offset = reader.getWALCurrentReadOffset();
-        while (reader.hasNext()) {
-          final WALEntry entry = reader.next();
-          try {
-            if (replayer.replay(entry)) {
-              statistics.replayedOperationCount++;
-            } else {
-              statistics.skippedEntryCount++;
-            }
-          } catch (final IoTDBConnectionException | StatementExecutionException e) {
-            throw new WALReplayException(
-                String.format(
-                    ImportWALMessages
-                        .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
-                    walFile,
-                    offset,
-                    e.getMessage()),
-                e);
-          }
-          offset = reader.getWALCurrentReadOffset();
-        }
-        if (reader.isFileCorrupted()) {
-          throw new WALReplayException(
-              String.format(
-                  ImportWALMessages
-                      .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
-                  walFile,
-                  reader.getWALCurrentReadOffset(),
-                  ImportWALMessages.EXCEPTION_THE_WAL_FILE_IS_TRUNCATED_OR_CORRUPTED_6B0734C5),
-              null);
-        }
-        statistics.completedFileCount++;
-        statistics.processedBytes += Files.size(walFile);
-        statistics.elapsedNanos = System.nanoTime() - startNanos;
-        if (progressStream != null) {
-          progressStream.printf(
-              ImportWALMessages
-                  .MESSAGE_PROGRESS_ARG_COMPLETED_FILES_ARG_TOTAL_FILES_ARG_PROCESSED_BYTES_ARG_TOTAL_BYTES_ARG_PERCENT_ARG_ELAPSED_SECONDS_ARG_RATE_ARG_MB_PER_SECOND_F1C1356F,
-              statistics.completedFileCount,
-              walFiles.size(),
-              statistics.processedBytes,
-              statistics.totalBytes,
-              statistics.getProgressPercent(),
-              statistics.getElapsedSeconds(),
-              statistics.getAverageRateMbPerSecond());
-          progressStream.println();
-        }
-      } catch (final IOException e) {
-        if (e instanceof WALReplayException walReplayException) {
-          throw walReplayException;
-        }
-        throw new WALReplayException(
-            String.format(
-                ImportWALMessages
-                    .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
-                walFile,
-                0,
-                e.getMessage()),
-            e);
-      }
+      recordCompletedFile(
+          statistics,
+          replayWALFile(walFile, replayer),
+          walFiles.size(),
+          startNanos,
+          progressStream);
     }
     if (deleteSource) {
       deleteSourceWALFiles(walFiles);
     }
     return statistics;
+  }
+
+  static ReplayStatistics replayWALDirectories(
+      final List<Path> walFiles,
+      final int threadNum,
+      final WALReplayWorkerFactory workerFactory,
+      final PrintStream progressStream,
+      final boolean deleteSource)
+      throws IOException {
+    if (threadNum <= 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              ImportWALMessages
+                  .EXCEPTION_INVALID_THREAD_COUNT_ARG_EXPECTED_A_POSITIVE_INTEGER_F3AE2CFD,
+              threadNum));
+    }
+    final long startNanos = System.nanoTime();
+    final ReplayStatistics statistics = createReplayStatistics(walFiles);
+    final List<List<Path>> walDirectories = groupWALFilesByDirectory(walFiles);
+    if (walDirectories.isEmpty()) {
+      statistics.elapsedNanos = System.nanoTime() - startNanos;
+      return statistics;
+    }
+
+    final int workerCount = Math.min(threadNum, walDirectories.size());
+    final AtomicInteger nextDirectoryIndex = new AtomicInteger();
+    final AtomicReference<Throwable> replayFailure = new AtomicReference<>();
+    final ExecutorService executor = Executors.newFixedThreadPool(workerCount);
+    final List<Future<?>> futures = new ArrayList<>(workerCount);
+    for (int i = 0; i < workerCount; i++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                try (WALReplayWorker worker = workerFactory.create()) {
+                  int directoryIndex;
+                  // A worker owns one directory at a time so WAL files from that directory remain
+                  // ordered, while independent directories can make progress concurrently.
+                  while (replayFailure.get() == null
+                      && (directoryIndex = nextDirectoryIndex.getAndIncrement())
+                          < walDirectories.size()) {
+                    for (final Path walFile : walDirectories.get(directoryIndex)) {
+                      recordCompletedFile(
+                          statistics,
+                          replayWALFile(walFile, worker),
+                          walFiles.size(),
+                          startNanos,
+                          progressStream);
+                    }
+                  }
+                } catch (final Exception e) {
+                  replayFailure.compareAndSet(null, e);
+                }
+              }));
+    }
+    executor.shutdown();
+
+    boolean interrupted = false;
+    for (final Future<?> future : futures) {
+      boolean completed = false;
+      // Wait for every worker even after a failure so sessions are closed before source deletion or
+      // the failure is reported to the caller.
+      while (!completed) {
+        try {
+          future.get();
+          completed = true;
+        } catch (final InterruptedException e) {
+          interrupted = true;
+          replayFailure.compareAndSet(
+              null,
+              new IOException(ImportWALMessages.EXCEPTION_WAL_REPLAY_WAS_INTERRUPTED_770BA8AD, e));
+        } catch (final ExecutionException e) {
+          replayFailure.compareAndSet(null, e.getCause());
+          completed = true;
+        }
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+    statistics.elapsedNanos = System.nanoTime() - startNanos;
+    rethrowReplayFailure(replayFailure.get());
+    if (deleteSource) {
+      deleteSourceWALFiles(walFiles);
+    }
+    return statistics;
+  }
+
+  static List<List<Path>> groupWALFilesByDirectory(final List<Path> walFiles) {
+    final List<Path> sortedWALFiles = new ArrayList<>(walFiles);
+    sortedWALFiles.sort(WAL_FILE_COMPARATOR);
+    final Map<Path, List<Path>> filesByDirectory = new LinkedHashMap<>();
+    for (final Path walFile : sortedWALFiles) {
+      filesByDirectory
+          .computeIfAbsent(walFile.getParent(), ignored -> new ArrayList<>())
+          .add(walFile);
+    }
+    return new ArrayList<>(filesByDirectory.values());
+  }
+
+  private static ReplayStatistics createReplayStatistics(final List<Path> walFiles)
+      throws IOException {
+    final ReplayStatistics statistics = new ReplayStatistics();
+    for (final Path walFile : walFiles) {
+      statistics.totalBytes += Files.size(walFile);
+    }
+    return statistics;
+  }
+
+  private static ReplayStatistics replayWALFile(final Path walFile, final WALReplayWorker replayer)
+      throws IOException {
+    final ReplayStatistics statistics = new ReplayStatistics();
+    try (WALReader reader = new WALReader(walFile.toFile())) {
+      long offset = reader.getWALCurrentReadOffset();
+      while (reader.hasNext()) {
+        final WALEntry entry = reader.next();
+        try {
+          if (replayer.replay(entry)) {
+            statistics.replayedOperationCount++;
+          } else {
+            statistics.skippedEntryCount++;
+          }
+        } catch (final IoTDBConnectionException | StatementExecutionException e) {
+          throw new WALReplayException(
+              String.format(
+                  ImportWALMessages
+                      .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
+                  walFile,
+                  offset,
+                  e.getMessage()),
+              e);
+        }
+        offset = reader.getWALCurrentReadOffset();
+      }
+      if (reader.isFileCorrupted()) {
+        throw new WALReplayException(
+            String.format(
+                ImportWALMessages
+                    .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
+                walFile,
+                reader.getWALCurrentReadOffset(),
+                ImportWALMessages.EXCEPTION_THE_WAL_FILE_IS_TRUNCATED_OR_CORRUPTED_6B0734C5),
+            null);
+      }
+      statistics.completedFileCount++;
+      statistics.processedBytes += Files.size(walFile);
+      return statistics;
+    } catch (final IOException e) {
+      if (e instanceof WALReplayException walReplayException) {
+        throw walReplayException;
+      }
+      throw new WALReplayException(
+          String.format(
+              ImportWALMessages.EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
+              walFile,
+              0,
+              e.getMessage()),
+          e);
+    }
+  }
+
+  private static void recordCompletedFile(
+      final ReplayStatistics statistics,
+      final ReplayStatistics completedFileStatistics,
+      final int totalFileCount,
+      final long startNanos,
+      final PrintStream progressStream) {
+    synchronized (statistics) {
+      statistics.add(completedFileStatistics);
+      statistics.elapsedNanos = System.nanoTime() - startNanos;
+      if (progressStream != null) {
+        progressStream.printf(
+            ImportWALMessages
+                .MESSAGE_PROGRESS_ARG_COMPLETED_FILES_ARG_TOTAL_FILES_ARG_PROCESSED_BYTES_ARG_TOTAL_BYTES_ARG_PERCENT_ARG_ELAPSED_SECONDS_ARG_RATE_ARG_MB_PER_SECOND_F1C1356F,
+            statistics.completedFileCount,
+            totalFileCount,
+            statistics.processedBytes,
+            statistics.totalBytes,
+            statistics.getProgressPercent(),
+            statistics.getElapsedSeconds(),
+            statistics.getAverageRateMbPerSecond());
+        progressStream.println();
+      }
+    }
+  }
+
+  private static void rethrowReplayFailure(final Throwable failure) throws IOException {
+    if (failure == null) {
+      return;
+    }
+    if (failure instanceof IOException ioException) {
+      throw ioException;
+    }
+    if (failure instanceof RuntimeException runtimeException) {
+      throw runtimeException;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new IOException(failure);
   }
 
   private static void deleteSourceWALFiles(final List<Path> walFiles) throws IOException {
@@ -498,7 +682,40 @@ public class ImportWAL {
     }
   }
 
-  static class WALReplayer {
+  @FunctionalInterface
+  interface WALReplayWorkerFactory {
+
+    WALReplayWorker create() throws Exception;
+  }
+
+  interface WALReplayWorker extends AutoCloseable {
+
+    boolean replay(WALEntry entry) throws IoTDBConnectionException, StatementExecutionException;
+
+    @Override
+    default void close() {}
+  }
+
+  private static class SessionWALReplayer extends WALReplayer {
+
+    private final Session treeSession;
+    private final Session tableSession;
+
+    private SessionWALReplayer(
+        final Session treeSession, final Session tableSession, final String tableDatabaseName) {
+      super(treeSession, tableSession, tableDatabaseName);
+      this.treeSession = treeSession;
+      this.tableSession = tableSession;
+    }
+
+    @Override
+    public void close() {
+      closeSession(tableSession);
+      closeSession(treeSession);
+    }
+  }
+
+  static class WALReplayer implements WALReplayWorker {
 
     private final Session treeSession;
     private final Session tableSession;
@@ -528,7 +745,8 @@ public class ImportWAL {
               null, null, ColumnFilterMatcher.matchAll(), tableDatabaseName);
     }
 
-    boolean replay(final WALEntry entry)
+    @Override
+    public boolean replay(final WALEntry entry)
         throws IoTDBConnectionException, StatementExecutionException {
       if (entry.getType() == WALEntryType.MEMORY_TABLE_SNAPSHOT
           || entry.getType() == WALEntryType.OLD_MEMORY_TABLE_SNAPSHOT) {
@@ -558,12 +776,14 @@ public class ImportWAL {
         return null;
       }
       return entry -> {
-        final String answer =
-            console.readLine(
-                ImportWALMessages
-                    .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650,
-                entry.getType());
-        return isSkipConfirmation(answer);
+        synchronized (CONSOLE_PROMPT_LOCK) {
+          final String answer =
+              console.readLine(
+                  ImportWALMessages
+                      .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650,
+                  entry.getType());
+          return isSkipConfirmation(answer);
+        }
       };
     }
 
@@ -997,6 +1217,13 @@ public class ImportWAL {
     private long processedBytes;
     private long completedFileCount;
     private long elapsedNanos;
+
+    private void add(final ReplayStatistics statistics) {
+      replayedOperationCount += statistics.replayedOperationCount;
+      skippedEntryCount += statistics.skippedEntryCount;
+      processedBytes += statistics.processedBytes;
+      completedFileCount += statistics.completedFileCount;
+    }
 
     long getReplayedOperationCount() {
       return replayedOperationCount;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
@@ -1,0 +1,977 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.tools;
+
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.db.i18n.ImportWALMessages;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.ObjectNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalDeleteDataNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalInsertRowNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalInsertRowsNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalInsertTabletNode;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.AlignedWritableMemChunk;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.IWritableMemChunk;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.IWritableMemChunkGroup;
+import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
+import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryType;
+import org.apache.iotdb.db.storageengine.dataregion.wal.io.WALReader;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileUtils;
+import org.apache.iotdb.db.subscription.broker.consensus.ConsensusLogToTabletConverter;
+import org.apache.iotdb.db.subscription.columnfilter.ColumnFilterMatcher;
+import org.apache.iotdb.db.utils.datastructure.AlignedTVList;
+import org.apache.iotdb.db.utils.datastructure.TVList;
+import org.apache.iotdb.isession.SessionDataSet;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.Session;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.enums.ColumnCategory;
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.utils.Binary;
+import org.apache.tsfile.utils.BitMap;
+import org.apache.tsfile.utils.DateUtils;
+import org.apache.tsfile.write.record.Tablet;
+import org.apache.tsfile.write.schema.IMeasurementSchema;
+import org.apache.tsfile.write.schema.MeasurementSchema;
+
+import java.io.Console;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ImportWAL {
+
+  private static final int CODE_OK = 0;
+  private static final int CODE_ERROR = 1;
+  private static final String DEFAULT_HOST = "127.0.0.1";
+  private static final int DEFAULT_PORT = 6667;
+  private static final String DEFAULT_USER = "root";
+  private static final int SNAPSHOT_TABLET_ROW_LIMIT = 1024;
+
+  private ImportWAL() {}
+
+  public static void main(final String[] args) {
+    System.exit(run(args, System.out, System.err));
+  }
+
+  static int run(final String[] args, final PrintStream out, final PrintStream err) {
+    final Options options = createOptions();
+    if (containsHelpOption(args)) {
+      printHelp(options, out);
+      return CODE_OK;
+    }
+
+    final CommandLine commandLine;
+    try {
+      commandLine = new DefaultParser().parse(options, args);
+    } catch (final ParseException e) {
+      err.printf(ImportWALMessages.MESSAGE_ARGUMENT_ERROR_ARG_A9767F62, e.getMessage());
+      err.println();
+      printHelp(options, err);
+      return CODE_ERROR;
+    }
+
+    try {
+      final Path source = Paths.get(commandLine.getOptionValue("file"));
+      final List<Path> walFiles = collectWALFiles(source);
+      final String database = commandLine.getOptionValue("database");
+      final String password = getPassword(commandLine);
+      final Session treeSession =
+          createSession(
+              commandLine.getOptionValue("host", DEFAULT_HOST),
+              parsePort(commandLine.getOptionValue("port", String.valueOf(DEFAULT_PORT))),
+              commandLine.getOptionValue("username", DEFAULT_USER),
+              password,
+              null);
+      final Session tableSession =
+          database == null
+              ? null
+              : createSession(
+                  commandLine.getOptionValue("host", DEFAULT_HOST),
+                  parsePort(commandLine.getOptionValue("port", String.valueOf(DEFAULT_PORT))),
+                  commandLine.getOptionValue("username", DEFAULT_USER),
+                  password,
+                  database);
+      try {
+        treeSession.open(false);
+        if (tableSession != null) {
+          tableSession.open(false);
+        }
+        final ReplayStatistics statistics =
+            replayWALFiles(walFiles, new WALReplayer(treeSession, tableSession, database), out);
+        out.printf(
+            ImportWALMessages
+                .MESSAGE_REPLAYED_ARG_OPERATIONS_FROM_ARG_WAL_FILES_SKIPPED_ARG_ENTRIES_F0D37E3A,
+            statistics.replayedOperationCount,
+            walFiles.size(),
+            statistics.skippedEntryCount);
+        out.println();
+        out.printf(
+            ImportWALMessages
+                .MESSAGE_IMPORT_DURATION_ARG_SECONDS_TOTAL_SIZE_ARG_BYTES_AVERAGE_RATE_ARG_MB_PER_SECOND_4B4EA58D,
+            statistics.getElapsedSeconds(),
+            statistics.getTotalBytes(),
+            statistics.getAverageRateMbPerSecond());
+        out.println();
+      } finally {
+        closeSession(tableSession);
+        closeSession(treeSession);
+      }
+      return CODE_OK;
+    } catch (final Exception e) {
+      err.printf(ImportWALMessages.MESSAGE_WAL_IMPORT_FAILED_ARG_55C014BA, e.getMessage());
+      err.println();
+      return CODE_ERROR;
+    }
+  }
+
+  private static Options createOptions() {
+    final Options options = new Options();
+    options.addOption(
+        Option.builder("f")
+            .longOpt("file")
+            .hasArg()
+            .required()
+            .desc(
+                ImportWALMessages
+                    .MESSAGE_PATH_OF_A_WAL_FILE_OR_A_DIRECTORY_CONTAINING_WAL_FILES_473D0554)
+            .build());
+    options.addOption(
+        Option.builder("h")
+            .longOpt("host")
+            .hasArg()
+            .desc(ImportWALMessages.MESSAGE_TARGET_IOTDB_HOST_DEFAULT_127_0_0_1_3729156F)
+            .build());
+    options.addOption(
+        Option.builder("p")
+            .longOpt("port")
+            .hasArg()
+            .desc(ImportWALMessages.MESSAGE_TARGET_IOTDB_RPC_PORT_DEFAULT_6667_FC0D345D)
+            .build());
+    options.addOption(
+        Option.builder("u")
+            .longOpt("username")
+            .hasArg()
+            .desc(ImportWALMessages.MESSAGE_TARGET_IOTDB_USERNAME_DEFAULT_ROOT_EB91453B)
+            .build());
+    options.addOption(
+        Option.builder("pw")
+            .longOpt("password")
+            .hasArg()
+            .desc(
+                ImportWALMessages
+                    .MESSAGE_TARGET_IOTDB_PASSWORD_PROMPTED_INTERACTIVELY_IF_OMITTED_29681961)
+            .build());
+    options.addOption(
+        Option.builder("db")
+            .longOpt("database")
+            .hasArg()
+            .desc(ImportWALMessages.MESSAGE_TARGET_DATABASE_FOR_TABLE_MODEL_WAL_ENTRIES_27BACD1C)
+            .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("help")
+            .desc(ImportWALMessages.MESSAGE_PRINT_THIS_HELP_MESSAGE_E800AF7A)
+            .build());
+    return options;
+  }
+
+  private static String getPassword(final CommandLine commandLine) {
+    return getPassword(commandLine, System.console());
+  }
+
+  static String getPassword(final CommandLine commandLine, final Console console) {
+    if (commandLine.hasOption("password")) {
+      return commandLine.getOptionValue("password");
+    }
+    if (console == null) {
+      throw new IllegalArgumentException(
+          ImportWALMessages
+              .EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD);
+    }
+    final char[] password =
+        console.readPassword(ImportWALMessages.MESSAGE_PASSWORD_PROMPT_F2D0E794);
+    if (password == null) {
+      throw new IllegalArgumentException(
+          ImportWALMessages
+              .EXCEPTION_PASSWORD_WAS_NOT_PROVIDED_AND_INTERACTIVE_INPUT_IS_UNAVAILABLE_40F42BCD);
+    }
+    return new String(password);
+  }
+
+  private static boolean containsHelpOption(final String[] args) {
+    if (args == null) {
+      return false;
+    }
+    for (final String arg : args) {
+      if ("--help".equals(arg) || "-help".equals(arg)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void printHelp(final Options options, final PrintStream stream) {
+    final HelpFormatter formatter = new HelpFormatter();
+    formatter.setWidth(120);
+    formatter.printHelp(
+        new PrintWriter(stream, true),
+        120,
+        ImportWALMessages.MESSAGE_IMPORT_WAL_5E42804E,
+        null,
+        options,
+        2,
+        2,
+        null,
+        true);
+  }
+
+  private static int parsePort(final String port) {
+    try {
+      final int value = Integer.parseInt(port);
+      if (value <= 0 || value > 65535) {
+        throw new NumberFormatException(port);
+      }
+      return value;
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format(ImportWALMessages.EXCEPTION_INVALID_PORT_ARG_A7CDD5AC, port), e);
+    }
+  }
+
+  private static Session createSession(
+      final String host,
+      final int port,
+      final String username,
+      final String password,
+      final String database) {
+    final Session.Builder builder =
+        new Session.Builder().host(host).port(port).username(username).password(password);
+    if (database != null) {
+      builder.sqlDialect("table").database(database);
+    }
+    return builder.build();
+  }
+
+  private static void closeSession(final Session session) {
+    if (session == null) {
+      return;
+    }
+    try {
+      session.close();
+    } catch (final IoTDBConnectionException ignored) {
+      // The import result has already been determined; closing failure must not hide it.
+    }
+  }
+
+  static List<Path> collectWALFiles(final Path source) throws IOException {
+    if (!Files.exists(source)) {
+      throw new IOException(
+          String.format(
+              ImportWALMessages.EXCEPTION_SOURCE_PATH_DOES_NOT_EXIST_ARG_7C806CA2, source));
+    }
+    if (Files.isRegularFile(source)) {
+      if (!isWALFile(source)) {
+        throw new IOException(
+            String.format(
+                ImportWALMessages.EXCEPTION_SOURCE_FILE_IS_NOT_A_WAL_FILE_ARG_14A43F76, source));
+      }
+      return List.of(source.toAbsolutePath().normalize());
+    }
+    if (!Files.isDirectory(source)) {
+      throw new IOException(
+          String.format(
+              ImportWALMessages.EXCEPTION_SOURCE_PATH_DOES_NOT_EXIST_ARG_7C806CA2, source));
+    }
+
+    final List<Path> walFiles;
+    try (Stream<Path> stream = Files.walk(source)) {
+      walFiles =
+          stream
+              .filter(Files::isRegularFile)
+              .filter(ImportWAL::isWALFile)
+              .map(path -> path.toAbsolutePath().normalize())
+              .sorted(WAL_FILE_COMPARATOR)
+              .collect(Collectors.toList());
+    }
+    if (walFiles.isEmpty()) {
+      throw new IOException(
+          String.format(ImportWALMessages.EXCEPTION_NO_WAL_FILES_FOUND_UNDER_ARG_45F7FA22, source));
+    }
+    return walFiles;
+  }
+
+  private static boolean isWALFile(final Path path) {
+    return path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".wal");
+  }
+
+  private static final Comparator<Path> WAL_FILE_COMPARATOR =
+      Comparator.comparing((Path path) -> Objects.toString(path.getParent(), ""))
+          .thenComparingLong(ImportWAL::getWALVersion)
+          .thenComparing(path -> path.getFileName().toString());
+
+  private static long getWALVersion(final Path path) {
+    final String filename = path.getFileName().toString();
+    return WALFileUtils.WAL_FILE_NAME_PATTERN.matcher(filename).find()
+        ? WALFileUtils.parseVersionId(filename)
+        : Long.MAX_VALUE;
+  }
+
+  static ReplayStatistics replayWALFiles(final List<Path> walFiles, final WALReplayer replayer)
+      throws IOException {
+    return replayWALFiles(walFiles, replayer, null);
+  }
+
+  static ReplayStatistics replayWALFiles(
+      final List<Path> walFiles, final WALReplayer replayer, final PrintStream progressStream)
+      throws IOException {
+    final ReplayStatistics statistics = new ReplayStatistics();
+    final long startNanos = System.nanoTime();
+    for (final Path walFile : walFiles) {
+      statistics.totalBytes += Files.size(walFile);
+    }
+    for (final Path walFile : walFiles) {
+      try (WALReader reader = new WALReader(walFile.toFile())) {
+        long offset = reader.getWALCurrentReadOffset();
+        while (reader.hasNext()) {
+          final WALEntry entry = reader.next();
+          try {
+            if (replayer.replay(entry)) {
+              statistics.replayedOperationCount++;
+            } else {
+              statistics.skippedEntryCount++;
+            }
+          } catch (final IoTDBConnectionException | StatementExecutionException e) {
+            throw new WALReplayException(
+                String.format(
+                    ImportWALMessages
+                        .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
+                    walFile,
+                    offset,
+                    e.getMessage()),
+                e);
+          }
+          offset = reader.getWALCurrentReadOffset();
+        }
+        if (reader.isFileCorrupted()) {
+          throw new WALReplayException(
+              String.format(
+                  ImportWALMessages
+                      .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
+                  walFile,
+                  reader.getWALCurrentReadOffset(),
+                  ImportWALMessages.EXCEPTION_THE_WAL_FILE_IS_TRUNCATED_OR_CORRUPTED_6B0734C5),
+              null);
+        }
+        statistics.completedFileCount++;
+        statistics.processedBytes += Files.size(walFile);
+        statistics.elapsedNanos = System.nanoTime() - startNanos;
+        if (progressStream != null) {
+          progressStream.printf(
+              ImportWALMessages
+                  .MESSAGE_PROGRESS_ARG_COMPLETED_FILES_ARG_TOTAL_FILES_ARG_PROCESSED_BYTES_ARG_TOTAL_BYTES_ARG_PERCENT_ARG_ELAPSED_SECONDS_ARG_RATE_ARG_MB_PER_SECOND_F1C1356F,
+              statistics.completedFileCount,
+              walFiles.size(),
+              statistics.processedBytes,
+              statistics.totalBytes,
+              statistics.getProgressPercent(),
+              statistics.getElapsedSeconds(),
+              statistics.getAverageRateMbPerSecond());
+          progressStream.println();
+        }
+      } catch (final IOException e) {
+        if (e instanceof WALReplayException walReplayException) {
+          throw walReplayException;
+        }
+        throw new WALReplayException(
+            String.format(
+                ImportWALMessages
+                    .EXCEPTION_FAILED_TO_REPLAY_WAL_FILE_ARG_AT_OFFSET_ARG_ARG_FCFAF7F9,
+                walFile,
+                0,
+                e.getMessage()),
+            e);
+      }
+    }
+    return statistics;
+  }
+
+  static class WALReplayer {
+
+    private final Session treeSession;
+    private final Session tableSession;
+    private final ConsensusLogToTabletConverter converter;
+    private final UnsupportedEntryPrompt unsupportedEntryPrompt;
+    private final Map<String, List<IMeasurementSchema>> tableTagSchemas = new HashMap<>();
+
+    WALReplayer(
+        final Session treeSession, final Session tableSession, final String tableDatabaseName) {
+      this(
+          treeSession,
+          tableSession,
+          tableDatabaseName,
+          createUnsupportedEntryPrompt(System.console()));
+    }
+
+    WALReplayer(
+        final Session treeSession,
+        final Session tableSession,
+        final String tableDatabaseName,
+        final UnsupportedEntryPrompt unsupportedEntryPrompt) {
+      this.treeSession = treeSession;
+      this.tableSession = tableSession;
+      this.unsupportedEntryPrompt = unsupportedEntryPrompt;
+      converter =
+          new ConsensusLogToTabletConverter(
+              null, null, ColumnFilterMatcher.matchAll(), tableDatabaseName);
+    }
+
+    boolean replay(final WALEntry entry)
+        throws IoTDBConnectionException, StatementExecutionException {
+      if (entry.getType() == WALEntryType.MEMORY_TABLE_SNAPSHOT
+          || entry.getType() == WALEntryType.OLD_MEMORY_TABLE_SNAPSHOT) {
+        return replayMemTableSnapshot((IMemTable) entry.getValue());
+      }
+      if (entry.getValue() instanceof InsertNode insertNode) {
+        replayInsert(insertNode);
+        return true;
+      }
+      if (entry.getValue() instanceof DeleteDataNode deleteDataNode) {
+        replayTreeDelete(deleteDataNode);
+        return true;
+      }
+      if (entry.getValue() instanceof RelationalDeleteDataNode
+          || entry.getValue() instanceof ObjectNode) {
+        // A null prompt means no interactive console is available, so preserve fail-fast behavior.
+        if (unsupportedEntryPrompt != null && unsupportedEntryPrompt.shouldSkip(entry)) {
+          return false;
+        }
+        throw unsupportedOperation(entry);
+      }
+      return false;
+    }
+
+    private static UnsupportedEntryPrompt createUnsupportedEntryPrompt(final Console console) {
+      if (console == null) {
+        return null;
+      }
+      return entry -> {
+        final String answer =
+            console.readLine(
+                ImportWALMessages
+                    .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650,
+                entry.getType());
+        return isSkipConfirmation(answer);
+      };
+    }
+
+    static boolean isSkipConfirmation(final String answer) {
+      return answer != null
+          && ("y".equalsIgnoreCase(answer.trim()) || "yes".equalsIgnoreCase(answer.trim()));
+    }
+
+    @FunctionalInterface
+    interface UnsupportedEntryPrompt {
+
+      boolean shouldSkip(WALEntry entry);
+    }
+
+    private static StatementExecutionException unsupportedOperation(final WALEntry entry) {
+      return new StatementExecutionException(
+          String.format(
+              ImportWALMessages.EXCEPTION_UNSUPPORTED_WAL_OPERATION_ARG_ABD227A0, entry.getType()));
+    }
+
+    private void replayInsert(final InsertNode node)
+        throws IoTDBConnectionException, StatementExecutionException {
+      if (node instanceof InsertRowsNode insertRowsNode
+          && !(node instanceof RelationalInsertRowsNode)) {
+        for (final InsertNode rowNode : insertRowsNode.getInsertRowNodeList()) {
+          replayInsert(rowNode);
+        }
+        return;
+      }
+      final List<Tablet> tablets = converter.convert(node);
+      if (tablets.isEmpty()) {
+        throw new StatementExecutionException(
+            String.format(
+                ImportWALMessages.EXCEPTION_INSERT_NODE_ARG_CONTAINS_NO_REPLAYABLE_DATA_5DA13453,
+                node.getType()));
+      }
+      final boolean tableModel = isTableModelInsert(node);
+      if (tableModel && tableSession == null) {
+        throw new StatementExecutionException(
+            ImportWALMessages.EXCEPTION_TABLE_MODEL_WAL_ENTRIES_REQUIRE_DB_DATABASE_F7597726);
+      }
+      for (final Tablet tablet : tablets) {
+        if (tableModel) {
+          tableSession.insertRelationalTablet(tablet);
+        } else if (node.isAligned()) {
+          treeSession.insertAlignedTablet(tablet);
+        } else {
+          treeSession.insertTablet(tablet);
+        }
+      }
+    }
+
+    private static boolean isTableModelInsert(final InsertNode node) {
+      return node instanceof RelationalInsertRowNode
+          || node instanceof RelationalInsertRowsNode
+          || node instanceof RelationalInsertTabletNode;
+    }
+
+    private void replayTreeDelete(final DeleteDataNode node)
+        throws IoTDBConnectionException, StatementExecutionException {
+      final List<String> paths = new ArrayList<>(node.getPathList().size());
+      for (final MeasurementPath path : node.getPathList()) {
+        paths.add(path.getFullPath());
+      }
+      treeSession.deleteData(paths, node.getDeleteStartTime(), node.getDeleteEndTime());
+    }
+
+    private boolean replayMemTableSnapshot(final IMemTable memTable)
+        throws IoTDBConnectionException, StatementExecutionException {
+      if (memTable == null || memTable.isSignalMemTable()) {
+        return false;
+      }
+      boolean replayed = false;
+      for (Map.Entry<IDeviceID, IWritableMemChunkGroup> deviceEntry :
+          memTable.getMemTableMap().entrySet()) {
+        final IDeviceID deviceId = deviceEntry.getKey();
+        final IWritableMemChunkGroup group = deviceEntry.getValue();
+        for (IWritableMemChunk chunk : group.getMemChunkMap().values()) {
+          if (chunk == null || chunk.isEmpty()) {
+            continue;
+          }
+          if (chunk instanceof AlignedWritableMemChunk) {
+            replayed |= replayAlignedMemChunk(deviceId, (AlignedWritableMemChunk) chunk);
+          } else {
+            replayed |= replayNonAlignedMemChunk(deviceId, chunk);
+          }
+        }
+      }
+      return replayed;
+    }
+
+    private boolean replayNonAlignedMemChunk(
+        final IDeviceID deviceId, final IWritableMemChunk chunk)
+        throws IoTDBConnectionException, StatementExecutionException {
+      final List<IMeasurementSchema> schemas = Collections.singletonList(chunk.getSchema());
+      final boolean tableModel = deviceId.isTableModel();
+      requireTableSessionIfNeeded(tableModel);
+      final TableTabletSchema tabletSchema = createTableTabletSchema(deviceId, schemas);
+      final List<TVList> lists = new ArrayList<>();
+      lists.addAll(chunk.getSortedList());
+      lists.add(chunk.getWorkingTVList());
+      boolean replayed = false;
+      for (TVList list : lists) {
+        if (list == null || list.rowCount() == 0) {
+          continue;
+        }
+        if (!list.isSorted()) {
+          list.sort();
+        }
+        for (int start = 0; start < list.rowCount(); start += SNAPSHOT_TABLET_ROW_LIMIT) {
+          final int end = Math.min(start + SNAPSHOT_TABLET_ROW_LIMIT, list.rowCount());
+          final Tablet tablet =
+              buildNonAlignedTablet(deviceId, tabletSchema, schemas, list, start, end);
+          sendTablet(tablet, tableModel, false);
+          replayed = true;
+        }
+      }
+      return replayed;
+    }
+
+    private boolean replayAlignedMemChunk(
+        final IDeviceID deviceId, final AlignedWritableMemChunk chunk)
+        throws IoTDBConnectionException, StatementExecutionException {
+      final boolean tableModel = deviceId.isTableModel();
+      requireTableSessionIfNeeded(tableModel);
+      final List<IMeasurementSchema> schemas = chunk.getSchemaList();
+      final TableTabletSchema tabletSchema = createTableTabletSchema(deviceId, schemas);
+      final List<AlignedTVList> lists = new ArrayList<>();
+      lists.addAll(chunk.getSortedList());
+      lists.add(chunk.getWorkingTVList());
+      boolean replayed = false;
+      for (AlignedTVList list : lists) {
+        if (list == null || list.rowCount() == 0) {
+          continue;
+        }
+        if (!list.isSorted()) {
+          list.sort();
+        }
+        final List<Integer> replayableRows = getReplayableAlignedRows(list);
+        for (int start = 0; start < replayableRows.size(); start += SNAPSHOT_TABLET_ROW_LIMIT) {
+          final int end = Math.min(start + SNAPSHOT_TABLET_ROW_LIMIT, replayableRows.size());
+          final Tablet tablet =
+              buildAlignedTablet(deviceId, tabletSchema, schemas, list, replayableRows, start, end);
+          sendTablet(tablet, tableModel, true);
+          replayed = true;
+        }
+      }
+      return replayed;
+    }
+
+    private static List<Integer> getReplayableAlignedRows(final AlignedTVList list) {
+      final List<Integer> replayableRows = new ArrayList<>(list.rowCount());
+      for (int row = 0; row < list.rowCount(); row++) {
+        if (!list.isTimeDeleted(row)) {
+          replayableRows.add(row);
+        }
+      }
+      return replayableRows;
+    }
+
+    private void requireTableSessionIfNeeded(final boolean tableModel)
+        throws StatementExecutionException {
+      if (tableModel && tableSession == null) {
+        throw new StatementExecutionException(
+            ImportWALMessages.EXCEPTION_TABLE_MODEL_WAL_ENTRIES_REQUIRE_DB_DATABASE_F7597726);
+      }
+    }
+
+    private TableTabletSchema createTableTabletSchema(
+        final IDeviceID deviceId, final List<IMeasurementSchema> fieldSchemas)
+        throws IoTDBConnectionException, StatementExecutionException {
+      if (!deviceId.isTableModel()) {
+        return new TableTabletSchema(fieldSchemas, null, 0);
+      }
+      final String tableName = deviceId.getTableName();
+      List<IMeasurementSchema> tagSchemas = tableTagSchemas.get(tableName);
+      if (tagSchemas == null) {
+        tagSchemas = new ArrayList<>();
+        try (SessionDataSet dataSet =
+            tableSession.executeQueryStatement("DESCRIBE " + quoteIdentifier(tableName))) {
+          final SessionDataSet.DataIterator iterator = dataSet.iterator();
+          while (iterator.next()) {
+            final String category = iterator.getString(3);
+            if ("TAG".equalsIgnoreCase(category)) {
+              tagSchemas.add(
+                  new MeasurementSchema(
+                      iterator.getString(1), TSDataType.valueOf(iterator.getString(2))));
+            }
+          }
+        }
+        tableTagSchemas.put(tableName, tagSchemas);
+      }
+      final List<IMeasurementSchema> schemas =
+          new ArrayList<>(tagSchemas.size() + fieldSchemas.size());
+      schemas.addAll(tagSchemas);
+      schemas.addAll(fieldSchemas);
+      final List<ColumnCategory> categories = new ArrayList<>(schemas.size());
+      categories.addAll(Collections.nCopies(tagSchemas.size(), ColumnCategory.TAG));
+      categories.addAll(Collections.nCopies(fieldSchemas.size(), ColumnCategory.FIELD));
+      return new TableTabletSchema(schemas, categories, tagSchemas.size());
+    }
+
+    static String quoteIdentifier(final String identifier) {
+      return "\"" + identifier.replace("\"", "\"\"") + "\"";
+    }
+
+    private void sendTablet(final Tablet tablet, final boolean tableModel, final boolean aligned)
+        throws IoTDBConnectionException, StatementExecutionException {
+      if (tableModel) {
+        tableSession.insertRelationalTablet(tablet);
+      } else if (aligned) {
+        treeSession.insertAlignedTablet(tablet);
+      } else {
+        treeSession.insertTablet(tablet);
+      }
+    }
+
+    private static Tablet buildNonAlignedTablet(
+        final IDeviceID deviceId,
+        final TableTabletSchema tabletSchema,
+        final List<IMeasurementSchema> sourceSchemas,
+        final TVList list,
+        final int start,
+        final int end) {
+      final int rowCount = end - start;
+      final long[] times = new long[rowCount];
+      final Object[] values = createValueArrays(tabletSchema.schemas, rowCount);
+      final BitMap[] bitMaps = new BitMap[tabletSchema.schemas.size()];
+      final int fieldColumnIndex = tabletSchema.tagCount;
+      final TSDataType type = sourceSchemas.get(0).getType();
+      for (int i = 0; i < rowCount; i++) {
+        final int scanIndex = start + i;
+        final int valueIndex = list.getValueIndex(scanIndex);
+        times[i] = list.getTime(scanIndex);
+        if (list.isNullValue(valueIndex)) {
+          if (bitMaps[fieldColumnIndex] == null) {
+            bitMaps[fieldColumnIndex] = new BitMap(rowCount);
+          }
+          bitMaps[fieldColumnIndex].mark(i);
+        } else {
+          putValue(values[fieldColumnIndex], i, type, list, scanIndex);
+        }
+      }
+      populateTableTags(deviceId, tabletSchema.categories, values, bitMaps, rowCount);
+      return tabletSchema.categories == null
+          ? new Tablet(deviceId.toString(), tabletSchema.schemas, times, values, bitMaps, rowCount)
+          : new Tablet(
+              deviceId.getTableName(),
+              tabletSchema.schemas,
+              tabletSchema.categories,
+              times,
+              values,
+              bitMaps,
+              rowCount);
+    }
+
+    private static Tablet buildAlignedTablet(
+        final IDeviceID deviceId,
+        final TableTabletSchema tabletSchema,
+        final List<IMeasurementSchema> sourceSchemas,
+        final AlignedTVList list,
+        final List<Integer> replayableRows,
+        final int start,
+        final int end) {
+      final int rowCount = end - start;
+      final long[] times = new long[rowCount];
+      final Object[] values = createValueArrays(tabletSchema.schemas, rowCount);
+      final BitMap[] bitMaps = new BitMap[tabletSchema.schemas.size()];
+      final List<TSDataType> types = list.getTsDataTypes();
+      for (int i = 0; i < rowCount; i++) {
+        final int scanIndex = replayableRows.get(start + i);
+        final int valueIndex = list.getValueIndex(scanIndex);
+        times[i] = list.getTime(scanIndex);
+        for (int c = 0; c < sourceSchemas.size(); c++) {
+          final int targetColumnIndex = tabletSchema.tagCount + c;
+          if (c >= types.size() || list.isNullValue(valueIndex, c)) {
+            if (bitMaps[targetColumnIndex] == null) {
+              bitMaps[targetColumnIndex] = new BitMap(rowCount);
+            }
+            bitMaps[targetColumnIndex].mark(i);
+          } else {
+            putValue(values[targetColumnIndex], i, types.get(c), list, valueIndex, c);
+          }
+        }
+      }
+      populateTableTags(deviceId, tabletSchema.categories, values, bitMaps, rowCount);
+      return tabletSchema.categories == null
+          ? new Tablet(deviceId.toString(), tabletSchema.schemas, times, values, bitMaps, rowCount)
+          : new Tablet(
+              deviceId.getTableName(),
+              tabletSchema.schemas,
+              tabletSchema.categories,
+              times,
+              values,
+              bitMaps,
+              rowCount);
+    }
+
+    private static void populateTableTags(
+        final IDeviceID deviceId,
+        final List<ColumnCategory> columnCategories,
+        final Object[] values,
+        final BitMap[] bitMaps,
+        final int rowCount) {
+      if (columnCategories == null) {
+        return;
+      }
+      int tagSegmentIndex = 1;
+      for (int columnIndex = 0; columnIndex < columnCategories.size(); columnIndex++) {
+        if (columnCategories.get(columnIndex) != ColumnCategory.TAG) {
+          continue;
+        }
+        final Object segment =
+            tagSegmentIndex < deviceId.segmentNum() ? deviceId.segment(tagSegmentIndex) : null;
+        tagSegmentIndex++;
+        final Binary tagValue =
+            segment == null ? null : new Binary(segment.toString(), TSFileConfig.STRING_CHARSET);
+        for (int row = 0; row < rowCount; row++) {
+          if (tagValue == null) {
+            if (bitMaps[columnIndex] == null) {
+              bitMaps[columnIndex] = new BitMap(rowCount);
+            }
+            bitMaps[columnIndex].mark(row);
+          } else {
+            ((Binary[]) values[columnIndex])[row] = tagValue;
+            if (bitMaps[columnIndex] != null) {
+              bitMaps[columnIndex].unmark(row);
+            }
+          }
+        }
+      }
+    }
+
+    private static Object createValueArray(final TSDataType type, final int rowCount) {
+      return switch (type) {
+        case BOOLEAN -> new boolean[rowCount];
+        case INT32 -> new int[rowCount];
+        case DATE -> new LocalDate[rowCount];
+        case INT64, TIMESTAMP -> new long[rowCount];
+        case FLOAT -> new float[rowCount];
+        case DOUBLE -> new double[rowCount];
+        case TEXT, STRING, BLOB, OBJECT -> new Binary[rowCount];
+        case VECTOR, UNKNOWN -> throw unsupportedSnapshotDataType(type);
+      };
+    }
+
+    private static Object[] createValueArrays(
+        final List<IMeasurementSchema> schemas, final int rowCount) {
+      final Object[] values = new Object[schemas.size()];
+      for (int column = 0; column < schemas.size(); column++) {
+        values[column] = createValueArray(schemas.get(column).getType(), rowCount);
+      }
+      return values;
+    }
+
+    private static void putValue(
+        final Object target,
+        final int targetIndex,
+        final TSDataType type,
+        final TVList list,
+        final int sourceIndex) {
+      switch (type) {
+        case BOOLEAN -> ((boolean[]) target)[targetIndex] = list.getBoolean(sourceIndex);
+        case INT32 -> ((int[]) target)[targetIndex] = list.getInt(sourceIndex);
+        case DATE ->
+            ((LocalDate[]) target)[targetIndex] =
+                DateUtils.parseIntToLocalDate(list.getInt(sourceIndex));
+        case INT64, TIMESTAMP -> ((long[]) target)[targetIndex] = list.getLong(sourceIndex);
+        case FLOAT -> ((float[]) target)[targetIndex] = list.getFloat(sourceIndex);
+        case DOUBLE -> ((double[]) target)[targetIndex] = list.getDouble(sourceIndex);
+        case TEXT, STRING, BLOB, OBJECT ->
+            ((Binary[]) target)[targetIndex] = list.getBinary(sourceIndex);
+        case VECTOR, UNKNOWN -> throw unsupportedSnapshotDataType(type);
+      }
+    }
+
+    private static void putValue(
+        final Object target,
+        final int targetIndex,
+        final TSDataType type,
+        final AlignedTVList list,
+        final int sourceIndex,
+        final int columnIndex) {
+      switch (type) {
+        case BOOLEAN ->
+            ((boolean[]) target)[targetIndex] =
+                list.getBooleanByValueIndex(sourceIndex, columnIndex);
+        case INT32 ->
+            ((int[]) target)[targetIndex] = list.getIntByValueIndex(sourceIndex, columnIndex);
+        case DATE ->
+            ((LocalDate[]) target)[targetIndex] =
+                DateUtils.parseIntToLocalDate(list.getIntByValueIndex(sourceIndex, columnIndex));
+        case INT64, TIMESTAMP ->
+            ((long[]) target)[targetIndex] = list.getLongByValueIndex(sourceIndex, columnIndex);
+        case FLOAT ->
+            ((float[]) target)[targetIndex] = list.getFloatByValueIndex(sourceIndex, columnIndex);
+        case DOUBLE ->
+            ((double[]) target)[targetIndex] = list.getDoubleByValueIndex(sourceIndex, columnIndex);
+        case TEXT, STRING, BLOB, OBJECT ->
+            ((Binary[]) target)[targetIndex] = list.getBinaryByValueIndex(sourceIndex, columnIndex);
+        case VECTOR, UNKNOWN -> throw unsupportedSnapshotDataType(type);
+      }
+    }
+
+    private static IllegalArgumentException unsupportedSnapshotDataType(final TSDataType type) {
+      return new IllegalArgumentException(
+          String.format(
+              ImportWALMessages.EXCEPTION_UNSUPPORTED_SNAPSHOT_DATA_TYPE_ARG_7A32D312, type));
+    }
+
+    private static class TableTabletSchema {
+      private final List<IMeasurementSchema> schemas;
+      private final List<ColumnCategory> categories;
+      private final int tagCount;
+
+      private TableTabletSchema(
+          final List<IMeasurementSchema> schemas,
+          final List<ColumnCategory> categories,
+          final int tagCount) {
+        this.schemas = schemas;
+        this.categories = categories;
+        this.tagCount = tagCount;
+      }
+    }
+  }
+
+  static class ReplayStatistics {
+    private long replayedOperationCount;
+    private long skippedEntryCount;
+    private long totalBytes;
+    private long processedBytes;
+    private long completedFileCount;
+    private long elapsedNanos;
+
+    long getReplayedOperationCount() {
+      return replayedOperationCount;
+    }
+
+    long getSkippedEntryCount() {
+      return skippedEntryCount;
+    }
+
+    long getTotalBytes() {
+      return totalBytes;
+    }
+
+    long getCompletedFileCount() {
+      return completedFileCount;
+    }
+
+    double getElapsedSeconds() {
+      return elapsedNanos / 1_000_000_000.0;
+    }
+
+    double getProgressPercent() {
+      return totalBytes == 0 ? 100.0 : processedBytes * 100.0 / totalBytes;
+    }
+
+    double getAverageRateMbPerSecond() {
+      final double elapsedSeconds = getElapsedSeconds();
+      return elapsedSeconds <= 0 ? 0.0 : processedBytes / elapsedSeconds / (1024.0 * 1024.0);
+    }
+  }
+
+  private static class WALReplayException extends IOException {
+    private WALReplayException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
@@ -98,7 +98,6 @@ public class ImportWAL {
   private static final String DEFAULT_USER = "root";
   private static final int DEFAULT_THREAD_NUM = 1;
   private static final int SNAPSHOT_TABLET_ROW_LIMIT = 1024;
-  private static final Object CONSOLE_PROMPT_LOCK = new Object();
 
   private ImportWAL() {}
 
@@ -136,11 +135,15 @@ public class ImportWAL {
       final String host = commandLine.getOptionValue("host", DEFAULT_HOST);
       final int port = parsePort(commandLine.getOptionValue("port", String.valueOf(DEFAULT_PORT)));
       final String username = commandLine.getOptionValue("username", DEFAULT_USER);
+      final WALReplayer.ReplayDecisionController replayDecisionController =
+          new WALReplayer.ReplayDecisionController(System.console());
       final ReplayStatistics statistics =
           replayWALDirectories(
               walFiles,
               threadNum,
-              () -> createWALReplayWorker(host, port, username, password, database),
+              () ->
+                  createWALReplayWorker(
+                      host, port, username, password, database, replayDecisionController),
               out,
               deleteSource);
       out.printf(
@@ -353,7 +356,8 @@ public class ImportWAL {
       final int port,
       final String username,
       final String password,
-      final String database)
+      final String database,
+      final WALReplayer.ReplayDecisionController replayDecisionController)
       throws IOException {
     final Session treeSession = createSession(host, port, username, password, null);
     final Session tableSession =
@@ -363,7 +367,7 @@ public class ImportWAL {
       if (tableSession != null) {
         tableSession.open(false);
       }
-      return new SessionWALReplayer(treeSession, tableSession, database);
+      return new SessionWALReplayer(treeSession, tableSession, database, replayDecisionController);
     } catch (final IoTDBConnectionException e) {
       closeSession(tableSession);
       closeSession(treeSession);
@@ -702,8 +706,11 @@ public class ImportWAL {
     private final Session tableSession;
 
     private SessionWALReplayer(
-        final Session treeSession, final Session tableSession, final String tableDatabaseName) {
-      super(treeSession, tableSession, tableDatabaseName);
+        final Session treeSession,
+        final Session tableSession,
+        final String tableDatabaseName,
+        final WALReplayer.ReplayDecisionController replayDecisionController) {
+      super(treeSession, tableSession, tableDatabaseName, replayDecisionController);
       this.treeSession = treeSession;
       this.tableSession = tableSession;
     }
@@ -720,7 +727,7 @@ public class ImportWAL {
     private final Session treeSession;
     private final Session tableSession;
     private final ConsensusLogToTabletConverter converter;
-    private final UnsupportedEntryPrompt unsupportedEntryPrompt;
+    private final ReplayDecisionPrompt replayDecisionPrompt;
     private final Map<String, List<IMeasurementSchema>> tableTagSchemas = new HashMap<>();
 
     WALReplayer(
@@ -729,17 +736,17 @@ public class ImportWAL {
           treeSession,
           tableSession,
           tableDatabaseName,
-          createUnsupportedEntryPrompt(System.console()));
+          new ReplayDecisionController(System.console()));
     }
 
     WALReplayer(
         final Session treeSession,
         final Session tableSession,
         final String tableDatabaseName,
-        final UnsupportedEntryPrompt unsupportedEntryPrompt) {
+        final ReplayDecisionPrompt replayDecisionPrompt) {
       this.treeSession = treeSession;
       this.tableSession = tableSession;
-      this.unsupportedEntryPrompt = unsupportedEntryPrompt;
+      this.replayDecisionPrompt = replayDecisionPrompt;
       converter =
           new ConsensusLogToTabletConverter(
               null, null, ColumnFilterMatcher.matchAll(), tableDatabaseName);
@@ -757,45 +764,111 @@ public class ImportWAL {
         return true;
       }
       if (entry.getValue() instanceof DeleteDataNode deleteDataNode) {
+        final ReplayDecision decision = replayDecisionPrompt.decide(entry, true);
+        if (decision == ReplayDecision.SKIP || decision == ReplayDecision.SKIP_ALL) {
+          return false;
+        }
+        if (decision == ReplayDecision.TERMINATE) {
+          throw replayTerminatedByUser();
+        }
         replayTreeDelete(deleteDataNode);
         return true;
       }
       if (entry.getValue() instanceof RelationalDeleteDataNode
           || entry.getValue() instanceof ObjectNode) {
-        // A null prompt means no interactive console is available, so preserve fail-fast behavior.
-        if (unsupportedEntryPrompt != null && unsupportedEntryPrompt.shouldSkip(entry)) {
+        final ReplayDecision decision = replayDecisionPrompt.decide(entry, false);
+        if (decision == ReplayDecision.SKIP || decision == ReplayDecision.SKIP_ALL) {
           return false;
+        }
+        if (decision == ReplayDecision.TERMINATE) {
+          throw replayTerminatedByUser();
         }
         throw unsupportedOperation(entry);
       }
       return false;
     }
 
-    private static UnsupportedEntryPrompt createUnsupportedEntryPrompt(final Console console) {
-      if (console == null) {
-        return null;
-      }
-      return entry -> {
-        synchronized (CONSOLE_PROMPT_LOCK) {
-          final String answer =
-              console.readLine(
-                  ImportWALMessages
-                      .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_SKIP_THIS_ENTRY_Y_N_DAFBE650,
-                  entry.getType());
-          return isSkipConfirmation(answer);
-        }
-      };
-    }
-
-    static boolean isSkipConfirmation(final String answer) {
-      return answer != null
-          && ("y".equalsIgnoreCase(answer.trim()) || "yes".equalsIgnoreCase(answer.trim()));
+    enum ReplayDecision {
+      EXECUTE,
+      SKIP,
+      EXECUTE_ALL,
+      SKIP_ALL,
+      TERMINATE
     }
 
     @FunctionalInterface
-    interface UnsupportedEntryPrompt {
+    interface ReplayDecisionPrompt {
 
-      boolean shouldSkip(WALEntry entry);
+      ReplayDecision decide(WALEntry entry, boolean treeDelete);
+    }
+
+    static class ReplayDecisionController implements ReplayDecisionPrompt {
+
+      private final Console console;
+      private ReplayDecision treeDeleteDecision;
+      private boolean skipAllUnsupportedEntries;
+
+      ReplayDecisionController(final Console console) {
+        this.console = console;
+      }
+
+      // The controller is shared by parallel workers so an "all" choice applies to the whole
+      // import rather than only to the WAL files assigned to one worker.
+      @Override
+      public synchronized ReplayDecision decide(final WALEntry entry, final boolean treeDelete) {
+        if (treeDelete && treeDeleteDecision != null) {
+          return treeDeleteDecision == ReplayDecision.EXECUTE_ALL
+              ? ReplayDecision.EXECUTE
+              : ReplayDecision.SKIP;
+        }
+        if (!treeDelete && skipAllUnsupportedEntries) {
+          return ReplayDecision.SKIP;
+        }
+        if (console == null) {
+          return ReplayDecision.TERMINATE;
+        }
+        final String answer =
+            console.readLine(
+                treeDelete
+                    ? ImportWALMessages
+                        .MESSAGE_TREE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_11E39FD7
+                    : ImportWALMessages
+                        .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_CHOOSE_S_SKIP_L_SKIP_ALL_Q_QUIT_0A734E52,
+                entry.getType());
+        final ReplayDecision decision = parseDecision(answer, treeDelete);
+        rememberAllDecision(decision, treeDelete);
+        return decision;
+      }
+
+      private void rememberAllDecision(final ReplayDecision decision, final boolean treeDelete) {
+        if (treeDelete
+            && (decision == ReplayDecision.EXECUTE_ALL || decision == ReplayDecision.SKIP_ALL)) {
+          treeDeleteDecision = decision;
+        } else if (!treeDelete && decision == ReplayDecision.SKIP_ALL) {
+          skipAllUnsupportedEntries = true;
+        }
+      }
+
+      static ReplayDecision parseDecision(final String answer, final boolean treeDelete) {
+        if (answer == null) {
+          return ReplayDecision.TERMINATE;
+        }
+        return switch (answer.trim().toLowerCase(Locale.ROOT)) {
+          case "e", "execute", "yes", "y" ->
+              treeDelete ? ReplayDecision.EXECUTE : ReplayDecision.TERMINATE;
+          case "s", "skip", "no", "n" -> ReplayDecision.SKIP;
+          case "a", "all", "execute_all" ->
+              treeDelete ? ReplayDecision.EXECUTE_ALL : ReplayDecision.TERMINATE;
+          case "l", "skip_all" -> ReplayDecision.SKIP_ALL;
+          case "q", "quit", "terminate", "t" -> ReplayDecision.TERMINATE;
+          default -> ReplayDecision.TERMINATE;
+        };
+      }
+    }
+
+    private static StatementExecutionException replayTerminatedByUser() {
+      return new StatementExecutionException(
+          ImportWALMessages.EXCEPTION_WAL_REPLAY_WAS_TERMINATED_BY_THE_USER_E0BD6197);
     }
 
     private static StatementExecutionException unsupportedOperation(final WALEntry entry) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
@@ -467,7 +467,7 @@ public class ImportWAL {
           progressStream);
     }
     if (deleteSource) {
-      deleteSourceWALFiles(walFiles);
+      deleteSourceWALFiles(statistics.fullyReplayedFiles);
     }
     return statistics;
   }
@@ -552,7 +552,7 @@ public class ImportWAL {
     statistics.elapsedNanos = System.nanoTime() - startNanos;
     rethrowReplayFailure(replayFailure.get());
     if (deleteSource) {
-      deleteSourceWALFiles(walFiles);
+      deleteSourceWALFiles(statistics.fullyReplayedFiles);
     }
     return statistics;
   }
@@ -581,15 +581,19 @@ public class ImportWAL {
   private static ReplayStatistics replayWALFile(final Path walFile, final WALReplayWorker replayer)
       throws IOException {
     final ReplayStatistics statistics = new ReplayStatistics();
+    boolean fullyReplayed = true;
     try (WALReader reader = new WALReader(walFile.toFile())) {
       long offset = reader.getWALCurrentReadOffset();
       while (reader.hasNext()) {
         final WALEntry entry = reader.next();
         try {
-          if (replayer.replay(entry)) {
-            statistics.replayedOperationCount++;
-          } else {
-            statistics.skippedEntryCount++;
+          switch (replayer.replay(entry)) {
+            case REPLAYED -> statistics.replayedOperationCount++;
+            case SKIPPED -> {
+              statistics.skippedEntryCount++;
+              fullyReplayed = false;
+            }
+            case IGNORED -> statistics.skippedEntryCount++;
           }
         } catch (final IoTDBConnectionException | StatementExecutionException e) {
           throw new WALReplayException(
@@ -615,6 +619,11 @@ public class ImportWAL {
       }
       statistics.completedFileCount++;
       statistics.processedBytes += Files.size(walFile);
+      // Ignored control entries carry no data to replay. A user-skipped operation, however,
+      // must keep its source WAL available even when every worker finishes without an exception.
+      if (fullyReplayed) {
+        statistics.fullyReplayedFiles.add(walFile);
+      }
       return statistics;
     } catch (final IOException e) {
       if (e instanceof WALReplayException walReplayException) {
@@ -694,10 +703,19 @@ public class ImportWAL {
 
   interface WALReplayWorker extends AutoCloseable {
 
-    boolean replay(WALEntry entry) throws IoTDBConnectionException, StatementExecutionException;
+    ReplayResult replay(WALEntry entry)
+        throws IoTDBConnectionException, StatementExecutionException;
 
     @Override
     default void close() {}
+  }
+
+  enum ReplayResult {
+    REPLAYED,
+    // The user skipped a data operation, so its source WAL must be retained.
+    SKIPPED,
+    // Control entries and empty snapshots require no replay and do not prevent source deletion.
+    IGNORED
   }
 
   private static class SessionWALReplayer extends WALReplayer {
@@ -753,39 +771,41 @@ public class ImportWAL {
     }
 
     @Override
-    public boolean replay(final WALEntry entry)
+    public ReplayResult replay(final WALEntry entry)
         throws IoTDBConnectionException, StatementExecutionException {
       if (entry.getType() == WALEntryType.MEMORY_TABLE_SNAPSHOT
           || entry.getType() == WALEntryType.OLD_MEMORY_TABLE_SNAPSHOT) {
-        return replayMemTableSnapshot((IMemTable) entry.getValue());
+        return replayMemTableSnapshot((IMemTable) entry.getValue())
+            ? ReplayResult.REPLAYED
+            : ReplayResult.IGNORED;
       }
       if (entry.getValue() instanceof InsertNode insertNode) {
         replayInsert(insertNode);
-        return true;
+        return ReplayResult.REPLAYED;
       }
       if (entry.getValue() instanceof DeleteDataNode deleteDataNode) {
         final ReplayDecision decision = replayDecisionPrompt.decide(entry, true);
         if (decision == ReplayDecision.SKIP || decision == ReplayDecision.SKIP_ALL) {
-          return false;
+          return ReplayResult.SKIPPED;
         }
         if (decision == ReplayDecision.TERMINATE) {
           throw replayTerminatedByUser();
         }
         replayTreeDelete(deleteDataNode);
-        return true;
+        return ReplayResult.REPLAYED;
       }
       if (entry.getValue() instanceof RelationalDeleteDataNode
           || entry.getValue() instanceof ObjectNode) {
         final ReplayDecision decision = replayDecisionPrompt.decide(entry, false);
         if (decision == ReplayDecision.SKIP || decision == ReplayDecision.SKIP_ALL) {
-          return false;
+          return ReplayResult.SKIPPED;
         }
         if (decision == ReplayDecision.TERMINATE) {
           throw replayTerminatedByUser();
         }
         throw unsupportedOperation(entry);
       }
-      return false;
+      return ReplayResult.IGNORED;
     }
 
     enum ReplayDecision {
@@ -1284,6 +1304,7 @@ public class ImportWAL {
   }
 
   static class ReplayStatistics {
+    private final List<Path> fullyReplayedFiles = new ArrayList<>();
     private long replayedOperationCount;
     private long skippedEntryCount;
     private long totalBytes;
@@ -1292,6 +1313,7 @@ public class ImportWAL {
     private long elapsedNanos;
 
     private void add(final ReplayStatistics statistics) {
+      fullyReplayedFiles.addAll(statistics.fullyReplayedFiles);
       replayedOperationCount += statistics.replayedOperationCount;
       skippedEntryCount += statistics.skippedEntryCount;
       processedBytes += statistics.processedBytes;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/ImportWAL.java
@@ -33,12 +33,14 @@ import org.apache.iotdb.db.storageengine.dataregion.memtable.AlignedWritableMemC
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IWritableMemChunk;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IWritableMemChunkGroup;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryType;
 import org.apache.iotdb.db.storageengine.dataregion.wal.io.WALReader;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileUtils;
 import org.apache.iotdb.db.subscription.broker.consensus.ConsensusLogToTabletConverter;
 import org.apache.iotdb.db.subscription.columnfilter.ColumnFilterMatcher;
+import org.apache.iotdb.db.tools.TableWALDeleteConverter.ConversionException;
 import org.apache.iotdb.db.utils.datastructure.AlignedTVList;
 import org.apache.iotdb.db.utils.datastructure.TVList;
 import org.apache.iotdb.isession.SessionDataSet;
@@ -86,6 +88,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -162,7 +165,8 @@ public class ImportWAL {
       out.println();
       if (deleteSource) {
         out.printf(
-            ImportWALMessages.MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B, walFiles.size());
+            ImportWALMessages.MESSAGE_DELETED_ARG_SOURCE_WAL_FILES_C7A5AA1B,
+            statistics.fullyReplayedFiles.size());
         out.println();
       }
       return CODE_OK;
@@ -746,7 +750,7 @@ public class ImportWAL {
     private final Session tableSession;
     private final ConsensusLogToTabletConverter converter;
     private final ReplayDecisionPrompt replayDecisionPrompt;
-    private final Map<String, List<IMeasurementSchema>> tableTagSchemas = new HashMap<>();
+    private final Map<String, TableSchema> tableSchemas = new HashMap<>();
 
     WALReplayer(
         final Session treeSession, final Session tableSession, final String tableDatabaseName) {
@@ -783,7 +787,8 @@ public class ImportWAL {
         replayInsert(insertNode);
         return ReplayResult.REPLAYED;
       }
-      if (entry.getValue() instanceof DeleteDataNode deleteDataNode) {
+      if (entry.getValue() instanceof DeleteDataNode
+          || entry.getValue() instanceof RelationalDeleteDataNode) {
         final ReplayDecision decision = replayDecisionPrompt.decide(entry, true);
         if (decision == ReplayDecision.SKIP || decision == ReplayDecision.SKIP_ALL) {
           return ReplayResult.SKIPPED;
@@ -791,21 +796,39 @@ public class ImportWAL {
         if (decision == ReplayDecision.TERMINATE) {
           throw replayTerminatedByUser();
         }
-        replayTreeDelete(deleteDataNode);
-        return ReplayResult.REPLAYED;
+        if (entry.getValue() instanceof DeleteDataNode deleteDataNode) {
+          replayTreeDelete(deleteDataNode);
+          return ReplayResult.REPLAYED;
+        }
+        final List<String> statements;
+        try {
+          statements = prepareTableDelete((RelationalDeleteDataNode) entry.getValue());
+        } catch (final ConversionException e) {
+          return replayUnsupportedEntry(entry, e);
+        }
+        // Execution stays outside the conversion fallback: a failed RPC may have applied data.
+        for (final String sql : statements) {
+          tableSession.executeNonQueryStatement(sql);
+        }
+        return statements.isEmpty() ? ReplayResult.IGNORED : ReplayResult.REPLAYED;
       }
-      if (entry.getValue() instanceof RelationalDeleteDataNode
-          || entry.getValue() instanceof ObjectNode) {
-        final ReplayDecision decision = replayDecisionPrompt.decide(entry, false);
-        if (decision == ReplayDecision.SKIP || decision == ReplayDecision.SKIP_ALL) {
-          return ReplayResult.SKIPPED;
-        }
-        if (decision == ReplayDecision.TERMINATE) {
-          throw replayTerminatedByUser();
-        }
-        throw unsupportedOperation(entry);
+      if (entry.getValue() instanceof ObjectNode) {
+        return replayUnsupportedEntry(entry, unsupportedOperation(entry));
       }
       return ReplayResult.IGNORED;
+    }
+
+    private ReplayResult replayUnsupportedEntry(
+        final WALEntry entry, final StatementExecutionException failure)
+        throws StatementExecutionException {
+      final ReplayDecision decision =
+          replayDecisionPrompt.decide(
+              entry, false, failure instanceof ConversionException ? failure.getMessage() : null);
+      return switch (decision) {
+        case SKIP, SKIP_ALL -> ReplayResult.SKIPPED;
+        case TERMINATE -> throw replayTerminatedByUser();
+        case EXECUTE, EXECUTE_ALL -> throw failure;
+      };
     }
 
     enum ReplayDecision {
@@ -819,66 +842,89 @@ public class ImportWAL {
     @FunctionalInterface
     interface ReplayDecisionPrompt {
 
-      ReplayDecision decide(WALEntry entry, boolean treeDelete);
+      ReplayDecision decide(WALEntry entry, boolean executableDelete);
+
+      default ReplayDecision decide(
+          final WALEntry entry, final boolean executableDelete, final String reason) {
+        return decide(entry, executableDelete);
+      }
     }
 
     static class ReplayDecisionController implements ReplayDecisionPrompt {
 
-      private final Console console;
+      private final BiFunction<String, Object, String> readLine;
       private ReplayDecision treeDeleteDecision;
+      private ReplayDecision tableDeleteDecision;
       private boolean skipAllUnsupportedEntries;
 
       ReplayDecisionController(final Console console) {
-        this.console = console;
+        this(console == null ? null : console::readLine);
+      }
+
+      ReplayDecisionController(final BiFunction<String, Object, String> readLine) {
+        this.readLine = readLine;
       }
 
       // The controller is shared by parallel workers so an "all" choice applies to the whole
       // import rather than only to the WAL files assigned to one worker.
       @Override
-      public synchronized ReplayDecision decide(final WALEntry entry, final boolean treeDelete) {
-        if (treeDelete && treeDeleteDecision != null) {
-          return treeDeleteDecision == ReplayDecision.EXECUTE_ALL
+      public ReplayDecision decide(final WALEntry entry, final boolean executableDelete) {
+        return decide(entry, executableDelete, null);
+      }
+
+      @Override
+      public synchronized ReplayDecision decide(
+          final WALEntry entry, final boolean executableDelete, final String reason) {
+        final boolean tableDelete = entry.getValue() instanceof RelationalDeleteDataNode;
+        final ReplayDecision rememberedDecision =
+            tableDelete ? tableDeleteDecision : treeDeleteDecision;
+        if (executableDelete && rememberedDecision != null) {
+          return rememberedDecision == ReplayDecision.EXECUTE_ALL
               ? ReplayDecision.EXECUTE
               : ReplayDecision.SKIP;
         }
-        if (!treeDelete && skipAllUnsupportedEntries) {
+        if (!executableDelete && skipAllUnsupportedEntries) {
           return ReplayDecision.SKIP;
         }
-        if (console == null) {
+        if (readLine == null) {
           return ReplayDecision.TERMINATE;
         }
         final String answer =
-            console.readLine(
-                treeDelete
-                    ? ImportWALMessages
-                        .MESSAGE_TREE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_11E39FD7
+            readLine.apply(
+                executableDelete
+                    ? (tableDelete
+                        ? ImportWALMessages
+                            .MESSAGE_TABLE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_0C8D178A
+                        : ImportWALMessages
+                            .MESSAGE_TREE_MODEL_DELETE_OPERATION_DETECTED_ARG_CHOOSE_E_EXECUTE_S_SKIP_A_EXECUTE_ALL_L_SKIP_ALL_Q_QUIT_11E39FD7)
                     : ImportWALMessages
                         .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_CHOOSE_S_SKIP_L_SKIP_ALL_Q_QUIT_0A734E52,
-                entry.getType());
-        final ReplayDecision decision = parseDecision(answer, treeDelete);
-        rememberAllDecision(decision, treeDelete);
+                reason == null ? entry.getType() : reason);
+        final ReplayDecision decision = parseDecision(answer, executableDelete);
+        // Approval for one data model must not implicitly authorize deletes in the other model.
+        if (executableDelete
+            && (decision == ReplayDecision.EXECUTE_ALL || decision == ReplayDecision.SKIP_ALL)) {
+          if (tableDelete) {
+            tableDeleteDecision = decision;
+          } else {
+            treeDeleteDecision = decision;
+          }
+        } else if (!executableDelete && decision == ReplayDecision.SKIP_ALL) {
+          skipAllUnsupportedEntries = true;
+        }
         return decision;
       }
 
-      private void rememberAllDecision(final ReplayDecision decision, final boolean treeDelete) {
-        if (treeDelete
-            && (decision == ReplayDecision.EXECUTE_ALL || decision == ReplayDecision.SKIP_ALL)) {
-          treeDeleteDecision = decision;
-        } else if (!treeDelete && decision == ReplayDecision.SKIP_ALL) {
-          skipAllUnsupportedEntries = true;
-        }
-      }
-
-      static ReplayDecision parseDecision(final String answer, final boolean treeDelete) {
+      static ReplayDecision parseDecision(final String answer, final boolean executableDelete) {
         if (answer == null) {
           return ReplayDecision.TERMINATE;
         }
         return switch (answer.trim().toLowerCase(Locale.ROOT)) {
           case "e", "execute", "yes", "y" ->
-              treeDelete ? ReplayDecision.EXECUTE : ReplayDecision.TERMINATE;
+              executableDelete ? ReplayDecision.EXECUTE : ReplayDecision.TERMINATE;
           case "s", "skip", "no", "n" -> ReplayDecision.SKIP;
           case "a", "all", "execute_all" ->
-              treeDelete ? ReplayDecision.EXECUTE_ALL : ReplayDecision.TERMINATE;
+              executableDelete ? ReplayDecision.EXECUTE_ALL : ReplayDecision.TERMINATE;
           case "l", "skip_all" -> ReplayDecision.SKIP_ALL;
           case "q", "quit", "terminate", "t" -> ReplayDecision.TERMINATE;
           default -> ReplayDecision.TERMINATE;
@@ -942,6 +988,35 @@ public class ImportWAL {
         paths.add(path.getFullPath());
       }
       treeSession.deleteData(paths, node.getDeleteStartTime(), node.getDeleteEndTime());
+    }
+
+    private List<String> prepareTableDelete(final RelationalDeleteDataNode node)
+        throws IoTDBConnectionException, StatementExecutionException {
+      requireTableSessionIfNeeded(true);
+      final Map<String, List<TableDeletionEntry>> entriesByTable = new LinkedHashMap<>();
+      for (final TableDeletionEntry entry : node.getModEntries()) {
+        entriesByTable
+            .computeIfAbsent(entry.getTableName(), ignored -> new ArrayList<>())
+            .add(entry);
+      }
+      final List<String> statements = new ArrayList<>();
+      // Validate the entire node before executing its first DELETE. A merged node can span tables,
+      // while each SQL statement can delete from only one table in the target -db session.
+      for (final Map.Entry<String, List<TableDeletionEntry>> entry : entriesByTable.entrySet()) {
+        final TableSchema schema = getTableSchema(entry.getKey());
+        final String sql =
+            new TableWALDeleteConverter(
+                    entry.getKey(),
+                    schema.timeColumn,
+                    schema.tagSchemas.stream()
+                        .map(IMeasurementSchema::getMeasurementName)
+                        .collect(Collectors.toList()))
+                .toSql(entry.getValue());
+        if (sql != null) {
+          statements.add(sql);
+        }
+      }
+      return statements;
     }
 
     private boolean replayMemTableSnapshot(final IMemTable memTable)
@@ -1051,24 +1126,8 @@ public class ImportWAL {
       if (!deviceId.isTableModel()) {
         return new TableTabletSchema(fieldSchemas, null, 0);
       }
-      final String tableName = deviceId.getTableName();
-      List<IMeasurementSchema> tagSchemas = tableTagSchemas.get(tableName);
-      if (tagSchemas == null) {
-        tagSchemas = new ArrayList<>();
-        try (SessionDataSet dataSet =
-            tableSession.executeQueryStatement("DESCRIBE " + quoteIdentifier(tableName))) {
-          final SessionDataSet.DataIterator iterator = dataSet.iterator();
-          while (iterator.next()) {
-            final String category = iterator.getString(3);
-            if ("TAG".equalsIgnoreCase(category)) {
-              tagSchemas.add(
-                  new MeasurementSchema(
-                      iterator.getString(1), TSDataType.valueOf(iterator.getString(2))));
-            }
-          }
-        }
-        tableTagSchemas.put(tableName, tagSchemas);
-      }
+      final List<IMeasurementSchema> tagSchemas =
+          getTableSchema(deviceId.getTableName()).tagSchemas;
       final List<IMeasurementSchema> schemas =
           new ArrayList<>(tagSchemas.size() + fieldSchemas.size());
       schemas.addAll(tagSchemas);
@@ -1078,6 +1137,34 @@ public class ImportWAL {
       categories.addAll(Collections.nCopies(fieldSchemas.size(), ColumnCategory.FIELD));
       return new TableTabletSchema(schemas, categories, tagSchemas.size());
     }
+
+    private TableSchema getTableSchema(final String tableName)
+        throws IoTDBConnectionException, StatementExecutionException {
+      TableSchema schema = tableSchemas.get(tableName);
+      if (schema == null) {
+        final List<IMeasurementSchema> tagSchemas = new ArrayList<>();
+        String timeColumn = null;
+        try (SessionDataSet dataSet =
+            tableSession.executeQueryStatement("DESCRIBE " + quoteIdentifier(tableName))) {
+          final SessionDataSet.DataIterator iterator = dataSet.iterator();
+          while (iterator.next()) {
+            final String category = iterator.getString(3);
+            if ("TAG".equalsIgnoreCase(category)) {
+              tagSchemas.add(
+                  new MeasurementSchema(
+                      iterator.getString(1), TSDataType.valueOf(iterator.getString(2))));
+            } else if ("TIME".equalsIgnoreCase(category)) {
+              timeColumn = iterator.getString(1);
+            }
+          }
+        }
+        schema = new TableSchema(tagSchemas, timeColumn);
+        tableSchemas.put(tableName, schema);
+      }
+      return schema;
+    }
+
+    private record TableSchema(List<IMeasurementSchema> tagSchemas, String timeColumn) {}
 
     static String quoteIdentifier(final String identifier) {
       return "\"" + identifier.replace("\"", "\"\"") + "\"";

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/TableWALDeleteConverter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/TableWALDeleteConverter.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.tools;
+
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Identifier;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.IsNotNullPredicate;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.IsNullPredicate;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LogicalExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LongLiteral;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.StringLiteral;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.util.ExpressionFormatter;
+import org.apache.iotdb.db.i18n.ImportWALMessages;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TagPredicate;
+import org.apache.iotdb.rpc.StatementExecutionException;
+
+import org.apache.tsfile.file.metadata.IDeviceID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BooleanLiteral.FALSE_LITERAL;
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BooleanLiteral.TRUE_LITERAL;
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression.Operator.EQUAL;
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LogicalExpression.Operator.AND;
+import static org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LogicalExpression.Operator.OR;
+
+/**
+ * Reconstructs row deletes using the target table's ordered TAG columns. The WAL stores TAG
+ * ordinals, not names, so the target TAG order must match the source table.
+ */
+final class TableWALDeleteConverter {
+
+  private final String tableName;
+  private final String timeColumn;
+  private final List<String> tagColumns;
+
+  TableWALDeleteConverter(
+      final String tableName, final String timeColumn, final List<String> tagColumns) {
+    this.tableName = tableName;
+    this.timeColumn = timeColumn;
+    this.tagColumns = tagColumns;
+  }
+
+  /** Returns null for a deletion that cannot match any row. */
+  String toSql(final List<TableDeletionEntry> entries) throws ConversionException {
+    if (timeColumn == null) {
+      throw new ConversionException(
+          String.format(
+              ImportWALMessages
+                  .EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TARGET_TABLE_ARG_HAS_NO_TIME_COLUMN_55B1C25C,
+              tableName));
+    }
+    final List<Expression> alternatives = new ArrayList<>();
+    for (final TableDeletionEntry entry : entries) {
+      // DELETE FROM removes whole rows; translating a column tombstone would widen the deletion.
+      if (!entry.getPredicate().getMeasurementNames().isEmpty()) {
+        throw new ConversionException(
+            String.format(
+                ImportWALMessages
+                    .EXCEPTION_CANNOT_REPLAY_COLUMN_SPECIFIC_DELETION_FOR_TABLE_ARG_AS_DELETE_FROM_4A7ACC93,
+                tableName));
+      }
+      final List<Expression> conditions = new ArrayList<>();
+      conditions.add(toExpression(entry.getPredicate().getTagPredicate()));
+      // Omit unbounded ends instead of doing arithmetic on inclusive long boundaries.
+      if (entry.getStartTime() != Long.MIN_VALUE) {
+        conditions.add(timeComparison(GREATER_THAN_OR_EQUAL, entry.getStartTime()));
+      }
+      if (entry.getEndTime() != Long.MAX_VALUE) {
+        conditions.add(timeComparison(LESS_THAN_OR_EQUAL, entry.getEndTime()));
+      }
+      alternatives.add(combine(AND, conditions));
+    }
+    // Keep each TAG predicate paired with its own interval when merging deletes for one table.
+    final Expression predicate = combine(OR, alternatives);
+    if (predicate == FALSE_LITERAL) {
+      return null;
+    }
+    return "DELETE FROM "
+        + ImportWAL.WALReplayer.quoteIdentifier(tableName)
+        + (predicate == TRUE_LITERAL
+            ? ""
+            : " WHERE " + ExpressionFormatter.formatExpression(predicate));
+  }
+
+  private Expression timeComparison(final ComparisonExpression.Operator operator, final long time) {
+    return new ComparisonExpression(
+        operator, new Identifier(timeColumn, true), new LongLiteral(Long.toString(time)));
+  }
+
+  private Expression toExpression(final TagPredicate predicate) throws ConversionException {
+    if (predicate instanceof TagPredicate.NOP) {
+      return TRUE_LITERAL;
+    }
+    if (predicate instanceof TagPredicate.SegmentExactMatch match) {
+      validateSegmentIndex(match.getSegmentIndex());
+      return match.getSegmentIndex() == 0
+          ? (Objects.equals(tableName, match.getPattern()) ? TRUE_LITERAL : FALSE_LITERAL)
+          : tagComparison(match.getSegmentIndex(), match.getPattern());
+    }
+    if (predicate instanceof TagPredicate.SegmentNotNull notNull) {
+      validateSegmentIndex(notNull.getSegmentIndex());
+      return notNull.getSegmentIndex() == 0
+          ? TRUE_LITERAL
+          : new IsNotNullPredicate(tagIdentifier(notNull.getSegmentIndex()));
+    }
+    if (predicate instanceof TagPredicate.FullExactMatch match) {
+      return deviceExpression(match.getDeviceID());
+    }
+    if (predicate instanceof TagPredicate.DeviceIn deviceIn) {
+      final List<Expression> devices = new ArrayList<>();
+      // Attribute-based deletes store the resolved device set in the WAL. Replaying that set
+      // avoids re-evaluating attributes that may have changed since the original deletion.
+      for (final IDeviceID device : deviceIn.getDeviceIDs()) {
+        devices.add(deviceExpression(device));
+      }
+      return combine(OR, devices);
+    }
+    if (predicate instanceof TagPredicate.And and) {
+      final List<Expression> conditions = new ArrayList<>();
+      for (final TagPredicate child : and.getPredicates()) {
+        conditions.add(toExpression(child));
+      }
+      return combine(AND, conditions);
+    }
+    throw new ConversionException(
+        String.format(
+            ImportWALMessages
+                .EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_UNSUPPORTED_TAG_PREDICATE_ARG_AD0753A8,
+            predicate.getClass().getSimpleName()));
+  }
+
+  private Expression deviceExpression(final IDeviceID device) throws ConversionException {
+    if (!tableName.equals(device.getTableName()) || device.segmentNum() > tagColumns.size() + 1) {
+      throw new ConversionException(
+          String.format(
+              ImportWALMessages
+                  .EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_DEVICE_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_A6320535,
+              device,
+              tableName));
+    }
+    final List<Expression> conditions = new ArrayList<>();
+    // Device IDs omit trailing null TAGs. Exact matching must explicitly constrain those TAGs.
+    for (int index = 1; index <= tagColumns.size(); index++) {
+      conditions.add(
+          tagComparison(
+              index, index < device.segmentNum() ? (String) device.segment(index) : null));
+    }
+    return combine(AND, conditions);
+  }
+
+  private Expression tagComparison(final int index, final String value) {
+    final Identifier column = tagIdentifier(index);
+    return value == null
+        ? new IsNullPredicate(column)
+        : new ComparisonExpression(EQUAL, column, new StringLiteral(value));
+  }
+
+  private Identifier tagIdentifier(final int index) {
+    // Segment zero is the table name; TAG segments start at one in the WAL format.
+    return new Identifier(tagColumns.get(index - 1), true);
+  }
+
+  private void validateSegmentIndex(final int index) throws ConversionException {
+    if (index < 0 || index > tagColumns.size()) {
+      throw new ConversionException(
+          String.format(
+              ImportWALMessages
+                  .EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TAG_SEGMENT_INDEX_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_D5E3CCEE,
+              index,
+              tableName));
+    }
+  }
+
+  private static Expression combine(
+      final LogicalExpression.Operator operator, final List<Expression> expressions) {
+    // DELETE's analyzer accepts TAG/time comparisons, not BooleanLiteral predicates. Use boolean
+    // sentinels only internally and simplify them before generating any SQL.
+    final Expression identity = operator == AND ? TRUE_LITERAL : FALSE_LITERAL;
+    final Expression absorbing = operator == AND ? FALSE_LITERAL : TRUE_LITERAL;
+    final List<Expression> terms = new ArrayList<>();
+    for (final Expression expression : expressions) {
+      if (expression == absorbing) {
+        return absorbing;
+      }
+      if (expression != identity) {
+        terms.add(expression);
+      }
+    }
+    return switch (terms.size()) {
+      case 0 -> identity;
+      case 1 -> terms.get(0);
+      default -> new LogicalExpression(operator, terms);
+    };
+  }
+
+  /** Only conversion limitations may be skipped; session and execution failures remain fatal. */
+  static final class ConversionException extends StatementExecutionException {
+
+    private ConversionException(final String message) {
+      super(message);
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
@@ -104,6 +104,26 @@ public class ImportWALTest {
         files);
   }
 
+  /** Covers CLI discovery of the source-file operation without opening a Session. */
+  @Test
+  public void testHelpDescribesDeleteSourceOption() {
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    final int exitCode =
+        ImportWAL.run(new String[] {"--help"}, new PrintStream(output), new PrintStream(output));
+
+    assertEquals(0, exitCode);
+    assertTrue(output.toString().contains("--on_success"));
+  }
+
+  /** Covers the default retention value, deletion value, normalization, and invalid input. */
+  @Test
+  public void testParseOnSuccessOption() {
+    assertFalse(ImportWAL.shouldDeleteSource("none"));
+    assertTrue(ImportWAL.shouldDeleteSource(" DELETE "));
+    assertThrows(IllegalArgumentException.class, () -> ImportWAL.shouldDeleteSource("unsupported"));
+  }
+
   /**
    * Covers a real WAL file containing one tree insert and one internal signal. The insert must be
    * sent once as a Tablet, while the signal is counted as skipped and no corruption is reported.
@@ -126,6 +146,49 @@ public class ImportWALTest {
     verify(treeSession).insertTablet(tabletCaptor.capture());
     assertEquals("root.sg.d1", tabletCaptor.getValue().getDeviceId());
     assertEquals(100, tabletCaptor.getValue().getTimestamp(0));
+    assertTrue(walFile.exists());
+  }
+
+  /** Covers opt-in deletion after every source WAL file completes successfully. */
+  @Test
+  public void testReplayDeletesSourceFilesAfterAllFilesSucceed() throws Exception {
+    final File firstWALFile = createWALFile(0);
+    final File secondWALFile = createWALFile(1);
+    writeWAL(
+        firstWALFile, new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.delete.d1", 1)));
+    writeWAL(
+        secondWALFile, new WALInfoEntry(2, WALTestUtils.getInsertRowNode("root.sg.delete.d2", 2)));
+
+    ImportWAL.replayWALFiles(
+        Arrays.asList(firstWALFile.toPath(), secondWALFile.toPath()),
+        new ImportWAL.WALReplayer(mock(Session.class), null, null),
+        null,
+        true);
+
+    assertFalse(firstWALFile.exists());
+    assertFalse(secondWALFile.exists());
+  }
+
+  /** Covers all-or-nothing replay gating: a later failure must retain every source WAL file. */
+  @Test
+  public void testReplayRetainsAllSourceFilesWhenAnyFileFails() throws Exception {
+    final File validWALFile = createWALFile(0);
+    final File corruptedWALFile = createWALFile(1);
+    writeWAL(
+        validWALFile, new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.retain.d1", 1)));
+    Files.write(corruptedWALFile.toPath(), new byte[] {WALEntryType.INSERT_ROW_NODE.getCode()});
+
+    assertThrows(
+        IOException.class,
+        () ->
+            ImportWAL.replayWALFiles(
+                Arrays.asList(validWALFile.toPath(), corruptedWALFile.toPath()),
+                new ImportWAL.WALReplayer(mock(Session.class), null, null),
+                null,
+                true));
+
+    assertTrue(validWALFile.exists());
+    assertTrue(corruptedWALFile.exists());
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
@@ -62,6 +62,12 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -70,6 +76,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -104,7 +111,7 @@ public class ImportWALTest {
         files);
   }
 
-  /** Covers CLI discovery of the source-file operation without opening a Session. */
+  /** Covers CLI discovery of source-file and parallel replay options without opening a Session. */
   @Test
   public void testHelpDescribesDeleteSourceOption() {
     final ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -114,6 +121,79 @@ public class ImportWALTest {
 
     assertEquals(0, exitCode);
     assertTrue(output.toString().contains("--on_success"));
+    assertTrue(output.toString().contains("--thread_num"));
+  }
+
+  /** Covers valid thread counts and rejects zero, negative, and non-numeric values. */
+  @Test
+  public void testParseThreadNumOption() {
+    assertEquals(1, ImportWAL.parseThreadNum("1"));
+    assertEquals(4, ImportWAL.parseThreadNum("4"));
+    assertThrows(IllegalArgumentException.class, () -> ImportWAL.parseThreadNum("0"));
+    assertThrows(IllegalArgumentException.class, () -> ImportWAL.parseThreadNum("-1"));
+    assertThrows(IllegalArgumentException.class, () -> ImportWAL.parseThreadNum("invalid"));
+  }
+
+  /**
+   * Covers directory-level parallel replay with two WAL files per directory. Different directories
+   * must overlap, while versions within each directory must retain ascending replay order.
+   */
+  @Test
+  public void testReplayWALDirectoriesInParallelAndPreserveDirectoryOrder() throws Exception {
+    final Path source = temporaryFolder.newFolder("parallel-wal-root").toPath();
+    final Path nodeA = Files.createDirectory(source.resolve("node-a"));
+    final Path nodeB = Files.createDirectory(source.resolve("node-b"));
+    final Path a1 = createWALFile(nodeA, 1);
+    final Path a2 = createWALFile(nodeA, 2);
+    final Path b1 = createWALFile(nodeB, 1);
+    final Path b2 = createWALFile(nodeB, 2);
+    writeWAL(a1.toFile(), new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.a", 1)));
+    writeWAL(a2.toFile(), new WALInfoEntry(2, WALTestUtils.getInsertRowNode("root.sg.a", 2)));
+    writeWAL(b1.toFile(), new WALInfoEntry(3, WALTestUtils.getInsertRowNode("root.sg.b", 1)));
+    writeWAL(b2.toFile(), new WALInfoEntry(4, WALTestUtils.getInsertRowNode("root.sg.b", 2)));
+    final List<Path> walFiles = ImportWAL.collectWALFiles(source);
+    final CyclicBarrier replayBarrier = new CyclicBarrier(2);
+    final AtomicInteger activeReplays = new AtomicInteger();
+    final AtomicInteger maxActiveReplays = new AtomicInteger();
+    final AtomicInteger createdWorkers = new AtomicInteger();
+    final Map<String, List<Long>> replayedTimestamps = new ConcurrentHashMap<>();
+
+    final ImportWAL.ReplayStatistics statistics =
+        ImportWAL.replayWALDirectories(
+            walFiles,
+            2,
+            () -> {
+              createdWorkers.incrementAndGet();
+              final Session session = mock(Session.class);
+              doAnswer(
+                      invocation -> {
+                        final Tablet tablet = invocation.getArgument(0);
+                        final int active = activeReplays.incrementAndGet();
+                        maxActiveReplays.accumulateAndGet(active, Math::max);
+                        try {
+                          replayBarrier.await(5, TimeUnit.SECONDS);
+                          replayedTimestamps
+                              .computeIfAbsent(
+                                  tablet.getDeviceId(), ignored -> new CopyOnWriteArrayList<>())
+                              .add(tablet.getTimestamp(0));
+                        } finally {
+                          activeReplays.decrementAndGet();
+                        }
+                        return null;
+                      })
+                  .when(session)
+                  .insertTablet(any(Tablet.class));
+              return new ImportWAL.WALReplayer(session, null, null);
+            },
+            null,
+            false);
+
+    assertEquals(2, createdWorkers.get());
+    assertTrue(maxActiveReplays.get() >= 2);
+    assertEquals(Arrays.asList(1L, 2L), replayedTimestamps.get("root.sg.a"));
+    assertEquals(Arrays.asList(1L, 2L), replayedTimestamps.get("root.sg.b"));
+    assertEquals(4, statistics.getReplayedOperationCount());
+    assertEquals(4, statistics.getCompletedFileCount());
   }
 
   /** Covers the default retention value, deletion value, normalization, and invalid input. */
@@ -189,6 +269,36 @@ public class ImportWALTest {
 
     assertTrue(validWALFile.exists());
     assertTrue(corruptedWALFile.exists());
+  }
+
+  /**
+   * Covers all-or-nothing deletion during directory-level parallel replay. A corrupted directory
+   * must retain WAL files from both the failed directory and another concurrently replayed one.
+   */
+  @Test
+  public void testParallelReplayRetainsAllSourceFilesWhenAnyDirectoryFails() throws Exception {
+    final Path source = temporaryFolder.newFolder("parallel-retain-wal-root").toPath();
+    final Path validDirectory = Files.createDirectory(source.resolve("valid"));
+    final Path corruptedDirectory = Files.createDirectory(source.resolve("corrupted"));
+    final Path validWALFile = createWALFile(validDirectory, 0);
+    final Path corruptedWALFile = createWALFile(corruptedDirectory, 0);
+    writeWAL(
+        validWALFile.toFile(),
+        new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.parallel.retain", 1)));
+    Files.write(corruptedWALFile, new byte[] {WALEntryType.INSERT_ROW_NODE.getCode()});
+
+    assertThrows(
+        IOException.class,
+        () ->
+            ImportWAL.replayWALDirectories(
+                ImportWAL.collectWALFiles(source),
+                2,
+                () -> new ImportWAL.WALReplayer(mock(Session.class), null, null),
+                null,
+                true));
+
+    assertTrue(Files.exists(validWALFile));
+    assertTrue(Files.exists(corruptedWALFile));
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.ObjectNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalDeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalInsertTabletNode;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
@@ -75,6 +76,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -412,10 +414,91 @@ public class ImportWALTest {
             20);
     final Session treeSession = mock(Session.class);
 
-    new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, deleteNode));
+    new ImportWAL.WALReplayer(
+            treeSession,
+            null,
+            null,
+            (entry, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.EXECUTE)
+        .replay(new WALInfoEntry(1, deleteNode));
 
     verify(treeSession)
         .deleteData(eq(Arrays.asList("root.sg.d1.s1", "root.sg.d2.*")), eq(10L), eq(20L));
+  }
+
+  @Test
+  public void testReplayTreeDeleteSkipsAfterConfirmation() throws Exception {
+    final DeleteDataNode deleteNode =
+        new DeleteDataNode(
+            new PlanNodeId(""), List.of(new MeasurementPath("root.sg.d1.s1")), 10, 20);
+    final Session treeSession = mock(Session.class);
+
+    final boolean replayed =
+        new ImportWAL.WALReplayer(
+                treeSession,
+                null,
+                null,
+                (entry, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.SKIP)
+            .replay(new WALInfoEntry(1, deleteNode));
+
+    assertFalse(replayed);
+    verify(treeSession, never()).deleteData(any(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void testReplayTreeDeleteExecuteAllAndSkipAllDecisions() throws Exception {
+    final DeleteDataNode deleteNode =
+        new DeleteDataNode(
+            new PlanNodeId(""), List.of(new MeasurementPath("root.sg.d1.s1")), 10, 20);
+    final Session treeSession = mock(Session.class);
+    final AtomicInteger executeAllPromptCount = new AtomicInteger();
+    final ImportWAL.WALReplayer.ReplayDecisionPrompt executeAllPrompt =
+        (entry, treeDelete) -> {
+          executeAllPromptCount.incrementAndGet();
+          return ImportWAL.WALReplayer.ReplayDecision.EXECUTE_ALL;
+        };
+    final ImportWAL.WALReplayer firstExecuteAllReplayer =
+        new ImportWAL.WALReplayer(treeSession, null, null, executeAllPrompt);
+    final ImportWAL.WALReplayer secondExecuteAllReplayer =
+        new ImportWAL.WALReplayer(treeSession, null, null, executeAllPrompt);
+
+    assertTrue(firstExecuteAllReplayer.replay(new WALInfoEntry(1, deleteNode)));
+    assertTrue(secondExecuteAllReplayer.replay(new WALInfoEntry(2, deleteNode)));
+    assertEquals(2, executeAllPromptCount.get());
+    verify(treeSession, times(2)).deleteData(any(), eq(10L), eq(20L));
+
+    final Session skippedTreeSession = mock(Session.class);
+    final AtomicInteger skipAllPromptCount = new AtomicInteger();
+    final ImportWAL.WALReplayer.ReplayDecisionPrompt skipAllPrompt =
+        (entry, treeDelete) -> {
+          skipAllPromptCount.incrementAndGet();
+          return ImportWAL.WALReplayer.ReplayDecision.SKIP_ALL;
+        };
+    final ImportWAL.WALReplayer firstSkipAllReplayer =
+        new ImportWAL.WALReplayer(skippedTreeSession, null, null, skipAllPrompt);
+    final ImportWAL.WALReplayer secondSkipAllReplayer =
+        new ImportWAL.WALReplayer(skippedTreeSession, null, null, skipAllPrompt);
+
+    assertFalse(firstSkipAllReplayer.replay(new WALInfoEntry(1, deleteNode)));
+    assertFalse(secondSkipAllReplayer.replay(new WALInfoEntry(2, deleteNode)));
+    assertEquals(2, skipAllPromptCount.get());
+    verify(skippedTreeSession, never()).deleteData(any(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void testReplayTreeDeleteTerminatesAfterConfirmation() throws Exception {
+    final DeleteDataNode deleteNode =
+        new DeleteDataNode(
+            new PlanNodeId(""), List.of(new MeasurementPath("root.sg.d1.s1")), 10, 20);
+
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new ImportWAL.WALReplayer(
+                    mock(Session.class),
+                    null,
+                    null,
+                    (entry, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.TERMINATE)
+                .replay(new WALInfoEntry(1, deleteNode)));
   }
 
   /** Covers an unsupported entry when the interactive user explicitly chooses to skip it. */
@@ -424,9 +507,37 @@ public class ImportWALTest {
     final WALEntry entry = mockUnsupportedEntry();
 
     final boolean replayed =
-        new ImportWAL.WALReplayer(mock(Session.class), null, null, ignored -> true).replay(entry);
+        new ImportWAL.WALReplayer(
+                mock(Session.class),
+                null,
+                null,
+                (ignored, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.SKIP)
+            .replay(entry);
 
     assertFalse(replayed);
+  }
+
+  @Test
+  public void testReplayUnsupportedEntriesSkipAllAfterConfirmation() throws Exception {
+    final AtomicInteger promptCount = new AtomicInteger();
+    final ImportWAL.WALReplayer.ReplayDecisionPrompt skipAllPrompt =
+        (entry, treeDelete) -> {
+          promptCount.incrementAndGet();
+          return ImportWAL.WALReplayer.ReplayDecision.SKIP_ALL;
+        };
+    final ImportWAL.WALReplayer relationalDeleteReplayer =
+        new ImportWAL.WALReplayer(mock(Session.class), null, null, skipAllPrompt);
+
+    assertFalse(relationalDeleteReplayer.replay(mockUnsupportedEntry()));
+    assertFalse(relationalDeleteReplayer.replay(mockUnsupportedEntry()));
+
+    final WALEntry objectEntry = mock(WALEntry.class);
+    when(objectEntry.getType()).thenReturn(WALEntryType.OBJECT_FILE_NODE);
+    when(objectEntry.getValue()).thenReturn(mock(ObjectNode.class));
+    final ImportWAL.WALReplayer objectNodeReplayer =
+        new ImportWAL.WALReplayer(mock(Session.class), null, null, skipAllPrompt);
+    assertFalse(objectNodeReplayer.replay(objectEntry));
+    assertEquals(3, promptCount.get());
   }
 
   /** Covers an unsupported entry when the interactive user declines the skip prompt. */
@@ -437,7 +548,11 @@ public class ImportWALTest {
     assertThrows(
         StatementExecutionException.class,
         () ->
-            new ImportWAL.WALReplayer(mock(Session.class), null, null, ignored -> false)
+            new ImportWAL.WALReplayer(
+                    mock(Session.class),
+                    null,
+                    null,
+                    (ignored, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.TERMINATE)
                 .replay(entry));
   }
 
@@ -448,17 +563,38 @@ public class ImportWALTest {
 
     assertThrows(
         StatementExecutionException.class,
-        () -> new ImportWAL.WALReplayer(mock(Session.class), null, null, null).replay(entry));
+        () ->
+            new ImportWAL.WALReplayer(
+                    mock(Session.class),
+                    null,
+                    null,
+                    new ImportWAL.WALReplayer.ReplayDecisionController((java.io.Console) null))
+                .replay(entry));
   }
 
-  /** Covers accepted confirmations and the safe default for all other prompt answers. */
   @Test
-  public void testUnsupportedEntrySkipConfirmationParsing() {
-    assertTrue(ImportWAL.WALReplayer.isSkipConfirmation("y"));
-    assertTrue(ImportWAL.WALReplayer.isSkipConfirmation(" YES "));
-    assertFalse(ImportWAL.WALReplayer.isSkipConfirmation("n"));
-    assertFalse(ImportWAL.WALReplayer.isSkipConfirmation(""));
-    assertFalse(ImportWAL.WALReplayer.isSkipConfirmation(null));
+  public void testReplayDecisionParsing() {
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.EXECUTE,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("e", true));
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.SKIP,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("s", true));
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.EXECUTE_ALL,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("a", true));
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.SKIP_ALL,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("l", true));
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.TERMINATE,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("a", false));
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.SKIP_ALL,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("l", false));
+    assertEquals(
+        ImportWAL.WALReplayer.ReplayDecision.TERMINATE,
+        ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("q", true));
   }
 
   /** Covers a non-aligned snapshot whose measurements have independent time axes. */

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.tools;
+
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalDeleteDataNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalInsertTabletNode;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.PrimitiveMemTable;
+import org.apache.iotdb.db.storageengine.dataregion.wal.WALTestUtils;
+import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
+import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryType;
+import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALInfoEntry;
+import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALSignalEntry;
+import org.apache.iotdb.db.storageengine.dataregion.wal.io.ILogWriter;
+import org.apache.iotdb.db.storageengine.dataregion.wal.io.WALFileTest;
+import org.apache.iotdb.db.storageengine.dataregion.wal.io.WALWriter;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALByteBufferForTest;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileStatus;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.Session;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.StringArrayDeviceID;
+import org.apache.tsfile.write.record.Tablet;
+import org.apache.tsfile.write.schema.IMeasurementSchema;
+import org.apache.tsfile.write.schema.MeasurementSchema;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ImportWALTest {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * Covers recursive directory discovery with WAL versions 2 and 10 in separate node folders. The
+   * result must ignore non-WAL files and preserve parent-folder then numeric-version order.
+   */
+  @Test
+  public void testCollectWALFilesRecursivelyAndSortByVersion() throws IOException {
+    final Path source = temporaryFolder.newFolder("wal-root").toPath();
+    final Path nodeA = Files.createDirectory(source.resolve("node-a"));
+    final Path nodeB = Files.createDirectory(source.resolve("node-b"));
+    final Path a10 = createWALFile(nodeA, 10);
+    final Path a2 = createWALFile(nodeA, 2);
+    final Path b1 = createWALFile(nodeB, 1);
+    Files.createFile(nodeA.resolve("ignore.txt"));
+
+    final List<Path> files = ImportWAL.collectWALFiles(source);
+
+    assertEquals(
+        Arrays.asList(
+            a2.toAbsolutePath().normalize(),
+            a10.toAbsolutePath().normalize(),
+            b1.toAbsolutePath().normalize()),
+        files);
+  }
+
+  /**
+   * Covers a real WAL file containing one tree insert and one internal signal. The insert must be
+   * sent once as a Tablet, while the signal is counted as skipped and no corruption is reported.
+   */
+  @Test
+  public void testReplayWALFileReplaysInsertAndSkipsInternalEntry() throws Exception {
+    final File walFile = createWALFile(0);
+    final InsertRowNode rowNode = WALTestUtils.getInsertRowNode("root.sg.d1", 100);
+    writeWAL(walFile, new WALInfoEntry(1, rowNode), new WALSignalEntry(WALEntryType.CLOSE_SIGNAL));
+    final Session treeSession = mock(Session.class);
+
+    final ImportWAL.ReplayStatistics statistics =
+        ImportWAL.replayWALFiles(
+            Collections.singletonList(walFile.toPath()),
+            new ImportWAL.WALReplayer(treeSession, null, null));
+
+    assertEquals(1, statistics.getReplayedOperationCount());
+    assertEquals(1, statistics.getSkippedEntryCount());
+    final ArgumentCaptor<Tablet> tabletCaptor = ArgumentCaptor.forClass(Tablet.class);
+    verify(treeSession).insertTablet(tabletCaptor.capture());
+    assertEquals("root.sg.d1", tabletCaptor.getValue().getDeviceId());
+    assertEquals(100, tabletCaptor.getValue().getTimestamp(0));
+  }
+
+  @Test
+  public void testReplayReportsProgressAndFileStatistics() throws Exception {
+    final File walFile = createWALFile(0);
+    writeWAL(
+        walFile,
+        new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.progress", 100)),
+        new WALSignalEntry(WALEntryType.CLOSE_SIGNAL));
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    final ImportWAL.ReplayStatistics statistics =
+        ImportWAL.replayWALFiles(
+            Collections.singletonList(walFile.toPath()),
+            new ImportWAL.WALReplayer(mock(Session.class), null, null),
+            new PrintStream(output));
+
+    assertEquals(1, statistics.getCompletedFileCount());
+    assertEquals(Files.size(walFile.toPath()), statistics.getTotalBytes());
+    assertTrue(statistics.getElapsedSeconds() >= 0);
+    assertTrue(output.toString().contains("1/1"));
+  }
+
+  /**
+   * Covers an active WAL containing one complete entry but no end marker or metadata. Replay must
+   * treat EOF at the entry boundary as clean and import the entry without waiting for writer close.
+   */
+  @Test
+  public void testReplayActiveWALFileAtEntryBoundary() throws Exception {
+    final File walFile = createWALFile(0);
+    final InsertRowNode rowNode = WALTestUtils.getInsertRowNode("root.sg.active", 102);
+    final Session treeSession = mock(Session.class);
+
+    try (WALWriter writer = new WALWriter(walFile)) {
+      writer.write(serializeWAL(new WALInfoEntry(1, rowNode)));
+      writer.force();
+
+      final ImportWAL.ReplayStatistics statistics =
+          ImportWAL.replayWALFiles(
+              Collections.singletonList(walFile.toPath()),
+              new ImportWAL.WALReplayer(treeSession, null, null));
+
+      assertEquals(1, statistics.getReplayedOperationCount());
+      assertEquals(0, statistics.getSkippedEntryCount());
+      verify(treeSession).insertTablet(any(Tablet.class));
+    }
+  }
+
+  /**
+   * Covers an aligned tree row. The replay must use the aligned Session API and must not fall back
+   * to the non-aligned Tablet API.
+   */
+  @Test
+  public void testReplayAlignedTreeInsertUsesAlignedSessionAPI() throws Exception {
+    final InsertRowNode rowNode = WALTestUtils.getInsertRowNode("root.sg.aligned", 101);
+    rowNode.setAligned(true);
+    final Session treeSession = mock(Session.class);
+
+    new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, rowNode));
+
+    verify(treeSession).insertAlignedTablet(any(Tablet.class));
+    verify(treeSession, never()).insertTablet(any(Tablet.class));
+  }
+
+  /**
+   * Covers a table-model WAL tablet with an explicit target database. Replay must use the table
+   * Session and retain the source table name in the converted Tablet.
+   */
+  @Test
+  public void testReplayTableInsertUsesRelationalSessionAPI() throws Exception {
+    final RelationalInsertTabletNode node = WALFileTest.getRelationalInsertTabletNode("table1");
+    final Session treeSession = mock(Session.class);
+    final Session tableSession = mock(Session.class);
+
+    new ImportWAL.WALReplayer(treeSession, tableSession, "db").replay(new WALInfoEntry(1, node));
+
+    final ArgumentCaptor<Tablet> tabletCaptor = ArgumentCaptor.forClass(Tablet.class);
+    verify(tableSession).insertRelationalTablet(tabletCaptor.capture());
+    assertEquals("table1", tabletCaptor.getValue().getTableName());
+    verify(treeSession, never()).insertTablet(any(Tablet.class));
+  }
+
+  /**
+   * Covers a table-model WAL insert without a target database. Replay must fail before issuing any
+   * write because WAL insert entries do not carry their source database name.
+   */
+  @Test
+  public void testReplayTableInsertRequiresDatabase() throws Exception {
+    final RelationalInsertTabletNode node = WALFileTest.getRelationalInsertTabletNode("table1");
+    final Session treeSession = mock(Session.class);
+
+    assertThrows(
+        StatementExecutionException.class,
+        () -> new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, node)));
+
+    verify(treeSession, never()).insertTablet(any(Tablet.class));
+  }
+
+  /**
+   * Covers a tree deletion with multiple paths and a bounded time range. Replay must pass the
+   * original paths and inclusive time bounds to Session.deleteData.
+   */
+  @Test
+  public void testReplayTreeDeletePreservesPathsAndTimeRange() throws Exception {
+    final DeleteDataNode deleteNode =
+        new DeleteDataNode(
+            new PlanNodeId(""),
+            Arrays.asList(
+                new MeasurementPath("root.sg.d1.s1"), new MeasurementPath("root.sg.d2.*")),
+            10,
+            20);
+    final Session treeSession = mock(Session.class);
+
+    new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, deleteNode));
+
+    verify(treeSession)
+        .deleteData(eq(Arrays.asList("root.sg.d1.s1", "root.sg.d2.*")), eq(10L), eq(20L));
+  }
+
+  /** Covers an unsupported entry when the interactive user explicitly chooses to skip it. */
+  @Test
+  public void testReplayUnsupportedEntrySkipsAfterConfirmation() throws Exception {
+    final WALEntry entry = mockUnsupportedEntry();
+
+    final boolean replayed =
+        new ImportWAL.WALReplayer(mock(Session.class), null, null, ignored -> true).replay(entry);
+
+    assertFalse(replayed);
+  }
+
+  /** Covers an unsupported entry when the interactive user declines the skip prompt. */
+  @Test
+  public void testReplayUnsupportedEntryFailsAfterDecliningSkip() {
+    final WALEntry entry = mockUnsupportedEntry();
+
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new ImportWAL.WALReplayer(mock(Session.class), null, null, ignored -> false)
+                .replay(entry));
+  }
+
+  /** Covers non-interactive execution, which must retain the original fail-fast behavior. */
+  @Test
+  public void testReplayUnsupportedEntryFailsWithoutInteractiveInput() {
+    final WALEntry entry = mockUnsupportedEntry();
+
+    assertThrows(
+        StatementExecutionException.class,
+        () -> new ImportWAL.WALReplayer(mock(Session.class), null, null, null).replay(entry));
+  }
+
+  /** Covers accepted confirmations and the safe default for all other prompt answers. */
+  @Test
+  public void testUnsupportedEntrySkipConfirmationParsing() {
+    assertTrue(ImportWAL.WALReplayer.isSkipConfirmation("y"));
+    assertTrue(ImportWAL.WALReplayer.isSkipConfirmation(" YES "));
+    assertFalse(ImportWAL.WALReplayer.isSkipConfirmation("n"));
+    assertFalse(ImportWAL.WALReplayer.isSkipConfirmation(""));
+    assertFalse(ImportWAL.WALReplayer.isSkipConfirmation(null));
+  }
+
+  /** Covers a non-aligned snapshot whose measurements have independent time axes. */
+  @Test
+  public void testReplayNonAlignedMemTableSnapshotAsTablets() throws Exception {
+    final PrimitiveMemTable memTable = new PrimitiveMemTable("root.sg", "0");
+    final List<IMeasurementSchema> schemas =
+        Arrays.asList(
+            new MeasurementSchema("s1", TSDataType.INT32),
+            new MeasurementSchema("s2", TSDataType.INT64));
+    final StringArrayDeviceID deviceId = new StringArrayDeviceID("root.sg.d1");
+    memTable.write(deviceId, schemas, 3, new Object[] {30, 300L});
+    memTable.write(deviceId, schemas, 1, new Object[] {10, null});
+    final Session treeSession = mock(Session.class);
+
+    new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, memTable));
+
+    final ArgumentCaptor<Tablet> tabletCaptor = ArgumentCaptor.forClass(Tablet.class);
+    verify(treeSession, times(2)).insertTablet(tabletCaptor.capture());
+    final Tablet s1Tablet =
+        tabletCaptor.getAllValues().stream()
+            .filter(tablet -> "s1".equals(tablet.getSchemas().get(0).getMeasurementName()))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+    assertEquals(2, s1Tablet.getRowSize());
+    assertEquals(1, s1Tablet.getTimestamp(0));
+    assertEquals(3, s1Tablet.getTimestamp(1));
+    assertArrayEquals(new int[] {10, 30}, (int[]) s1Tablet.getValues()[0]);
+  }
+
+  /** Covers an aligned snapshot with nulls and verifies the aligned Session API is used. */
+  @Test
+  public void testReplayAlignedMemTableSnapshotPreservesNulls() throws Exception {
+    final PrimitiveMemTable memTable = new PrimitiveMemTable("root.sg", "0");
+    final List<IMeasurementSchema> schemas =
+        Arrays.asList(
+            new MeasurementSchema("s1", TSDataType.INT32),
+            new MeasurementSchema("s2", TSDataType.INT64));
+    final StringArrayDeviceID deviceId = new StringArrayDeviceID("root.sg.d1");
+    memTable.writeAlignedRow(deviceId, schemas, 2, new Object[] {20, null});
+    memTable.writeAlignedRow(deviceId, schemas, 1, new Object[] {10, 100L});
+    final Session treeSession = mock(Session.class);
+
+    new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, memTable));
+
+    final ArgumentCaptor<Tablet> tabletCaptor = ArgumentCaptor.forClass(Tablet.class);
+    verify(treeSession).insertAlignedTablet(tabletCaptor.capture());
+    verify(treeSession, never()).insertTablet(any(Tablet.class));
+    final Tablet tablet = tabletCaptor.getValue();
+    assertEquals(2, tablet.getRowSize());
+    assertEquals(1, tablet.getTimestamp(0));
+    assertEquals(2, tablet.getTimestamp(1));
+    assertArrayEquals(new int[] {10, 20}, (int[]) tablet.getValues()[0]);
+    assertTrue(tablet.getBitMaps()[1].isMarked(1));
+  }
+
+  /** Covers snapshot serialization and deserialization through a real WAL file. */
+  @Test
+  public void testReplaySerializedMemTableSnapshot() throws Exception {
+    final PrimitiveMemTable memTable = new PrimitiveMemTable("root.sg", "0");
+    memTable.write(
+        new StringArrayDeviceID("root.sg.d1"),
+        Collections.singletonList(new MeasurementSchema("s1", TSDataType.INT32)),
+        7,
+        new Object[] {70});
+    final File walFile = createWALFile(0);
+    writeWAL(walFile, new WALInfoEntry(1, memTable));
+    final Session treeSession = mock(Session.class);
+
+    final ImportWAL.ReplayStatistics statistics =
+        ImportWAL.replayWALFiles(
+            Collections.singletonList(walFile.toPath()),
+            new ImportWAL.WALReplayer(treeSession, null, null));
+
+    assertEquals(1, statistics.getReplayedOperationCount());
+    final ArgumentCaptor<Tablet> tabletCaptor = ArgumentCaptor.forClass(Tablet.class);
+    verify(treeSession).insertTablet(tabletCaptor.capture());
+    assertEquals(7, tabletCaptor.getValue().getTimestamp(0));
+    assertEquals(70, ((int[]) tabletCaptor.getValue().getValues()[0])[0]);
+  }
+
+  /** Covers a snapshot larger than the replay batch limit. */
+  @Test
+  public void testReplayMemTableSnapshotSplitsLargeChunk() throws Exception {
+    final PrimitiveMemTable memTable = new PrimitiveMemTable("root.sg", "0");
+    final List<IMeasurementSchema> schemas =
+        Collections.singletonList(new MeasurementSchema("s1", TSDataType.INT32));
+    final StringArrayDeviceID deviceId = new StringArrayDeviceID("root.sg.d1");
+    for (int i = 0; i < 1025; i++) {
+      memTable.write(deviceId, schemas, i, new Object[] {i});
+    }
+    final Session treeSession = mock(Session.class);
+
+    new ImportWAL.WALReplayer(treeSession, null, null).replay(new WALInfoEntry(1, memTable));
+
+    final ArgumentCaptor<Tablet> tabletCaptor = ArgumentCaptor.forClass(Tablet.class);
+    verify(treeSession, times(2)).insertTablet(tabletCaptor.capture());
+    assertEquals(1024, tabletCaptor.getAllValues().get(0).getRowSize());
+    assertEquals(1, tabletCaptor.getAllValues().get(1).getRowSize());
+  }
+
+  /** Covers a signal snapshot, which carries no user data and must be skipped. */
+  @Test
+  public void testReplaySignalMemTableSnapshotIsSkipped() throws Exception {
+    final IMemTable signalMemTable = mock(IMemTable.class);
+    when(signalMemTable.isSignalMemTable()).thenReturn(true);
+    final Session treeSession = mock(Session.class);
+
+    final boolean replayed =
+        new ImportWAL.WALReplayer(treeSession, null, null)
+            .replay(new WALInfoEntry(1, signalMemTable));
+
+    assertFalse(replayed);
+    verify(treeSession, never()).insertTablet(any(Tablet.class));
+    verify(treeSession, never()).insertAlignedTablet(any(Tablet.class));
+  }
+
+  /** Covers a table-model snapshot without a target database. */
+  @Test
+  public void testReplayTableMemTableSnapshotRequiresDatabase() throws Exception {
+    final PrimitiveMemTable memTable = new PrimitiveMemTable("db", "0");
+    memTable.writeAlignedRow(
+        new StringArrayDeviceID("table1", "device1"),
+        Collections.singletonList(new MeasurementSchema("temperature", TSDataType.FLOAT)),
+        1,
+        new Object[] {1.0F});
+    final Session treeSession = mock(Session.class);
+
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new ImportWAL.WALReplayer(treeSession, null, null)
+                .replay(new WALInfoEntry(1, memTable)));
+
+    verify(treeSession, never()).insertAlignedTablet(any(Tablet.class));
+  }
+
+  /** Covers table-model identifier quoting, including an embedded double quote. */
+  @Test
+  public void testQuoteTableIdentifierForDescribe() {
+    assertEquals("\"table\"", ImportWAL.WALReplayer.quoteIdentifier("table"));
+    assertEquals("\"table\"\"name\"", ImportWAL.WALReplayer.quoteIdentifier("table\"name"));
+  }
+
+  /**
+   * Covers a truncated WAL that cannot yield a complete entry. The file-level replay must fail so
+   * callers cannot mistake a partial replay for success.
+   */
+  @Test
+  public void testReplayWALFileFailsOnCorruption() throws Exception {
+    final File walFile = createWALFile(0);
+    Files.write(walFile.toPath(), new byte[] {WALEntryType.INSERT_ROW_NODE.getCode()});
+
+    final IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                ImportWAL.replayWALFiles(
+                    Collections.singletonList(walFile.toPath()),
+                    new ImportWAL.WALReplayer(mock(Session.class), null, null)));
+
+    assertTrue(exception.getMessage().contains(walFile.getName()));
+  }
+
+  @Test
+  public void testPasswordIsRequiredWhenInteractiveInputIsUnavailable() {
+    final CommandLine commandLine = mock(CommandLine.class);
+    when(commandLine.hasOption("password")).thenReturn(false);
+
+    assertThrows(IllegalArgumentException.class, () -> ImportWAL.getPassword(commandLine, null));
+  }
+
+  @Test
+  public void testExplicitPasswordTakesPrecedence() {
+    final CommandLine commandLine = mock(CommandLine.class);
+    when(commandLine.hasOption("password")).thenReturn(true);
+    when(commandLine.getOptionValue("password")).thenReturn("secret");
+
+    assertEquals("secret", ImportWAL.getPassword(commandLine, null));
+  }
+
+  private Path createWALFile(final Path parent, final long version) throws IOException {
+    return Files.createFile(
+        parent.resolve(
+            WALFileUtils.getLogFileName(version, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)));
+  }
+
+  private File createWALFile(final long version) throws IOException {
+    return temporaryFolder.newFile(
+        WALFileUtils.getLogFileName(version, 0, WALFileStatus.CONTAINS_SEARCH_INDEX));
+  }
+
+  private static void writeWAL(final File walFile, final WALEntry... entries) throws IOException {
+    try (ILogWriter writer = new WALWriter(walFile)) {
+      writer.write(serializeWAL(entries));
+    }
+  }
+
+  private static ByteBuffer serializeWAL(final WALEntry... entries) {
+    int serializedSize = 0;
+    for (final WALEntry entry : entries) {
+      serializedSize += entry.serializedSize();
+    }
+    final WALByteBufferForTest buffer =
+        new WALByteBufferForTest(ByteBuffer.allocate(serializedSize));
+    for (final WALEntry entry : entries) {
+      entry.serialize(buffer);
+    }
+    return buffer.getBuffer();
+  }
+
+  private static WALEntry mockUnsupportedEntry() {
+    final WALEntry entry = mock(WALEntry.class);
+    when(entry.getType()).thenReturn(WALEntryType.RELATIONAL_DELETE_DATA_NODE);
+    when(entry.getValue()).thenReturn(mock(RelationalDeleteDataNode.class));
+    return entry;
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.tools;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.i18n.ImportWALMessages;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.ContinuousSameSearchIndexSeparatorNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
@@ -31,6 +32,7 @@ import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.PrimitiveMemTable;
 import org.apache.iotdb.db.storageengine.dataregion.modification.DeletionPredicate;
 import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TagPredicate;
 import org.apache.iotdb.db.storageengine.dataregion.wal.WALTestUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryType;
@@ -44,6 +46,9 @@ import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileStatus;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileUtils;
 import org.apache.iotdb.db.tools.ImportWAL.ReplayResult;
 import org.apache.iotdb.db.tools.ImportWAL.WALReplayer.ReplayDecision;
+import org.apache.iotdb.db.tools.ImportWAL.WALReplayer.ReplayDecisionController;
+import org.apache.iotdb.isession.SessionDataSet;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
 
@@ -60,6 +65,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -85,10 +91,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ImportWALTest {
@@ -613,7 +621,7 @@ public class ImportWALTest {
     assertEquals(ReplayResult.SKIPPED, result);
   }
 
-  /** Table deletes and ObjectNode entries skipped with SKIP_ALL must both retain their WALs. */
+  /** Unsupported ObjectNode entries skipped with SKIP_ALL must retain their source WALs. */
   @Test
   public void testReplayUnsupportedEntriesSkipAllAfterConfirmation() throws Exception {
     final AtomicInteger promptCount = new AtomicInteger();
@@ -622,19 +630,12 @@ public class ImportWALTest {
           promptCount.incrementAndGet();
           return ImportWAL.WALReplayer.ReplayDecision.SKIP_ALL;
         };
-    final ImportWAL.WALReplayer relationalDeleteReplayer =
+    final ImportWAL.WALReplayer replayer =
         new ImportWAL.WALReplayer(mock(Session.class), null, null, skipAllPrompt);
 
-    assertEquals(ReplayResult.SKIPPED, relationalDeleteReplayer.replay(mockUnsupportedEntry()));
-    assertEquals(ReplayResult.SKIPPED, relationalDeleteReplayer.replay(mockUnsupportedEntry()));
-
-    final WALEntry objectEntry = mock(WALEntry.class);
-    when(objectEntry.getType()).thenReturn(WALEntryType.OBJECT_FILE_NODE);
-    when(objectEntry.getValue()).thenReturn(mock(ObjectNode.class));
-    final ImportWAL.WALReplayer objectNodeReplayer =
-        new ImportWAL.WALReplayer(mock(Session.class), null, null, skipAllPrompt);
-    assertEquals(ReplayResult.SKIPPED, objectNodeReplayer.replay(objectEntry));
-    assertEquals(3, promptCount.get());
+    assertEquals(ReplayResult.SKIPPED, replayer.replay(mockUnsupportedEntry()));
+    assertEquals(ReplayResult.SKIPPED, replayer.replay(mockUnsupportedEntry()));
+    assertEquals(2, promptCount.get());
   }
 
   /** Covers an unsupported entry when the interactive user declines the skip prompt. */
@@ -665,7 +666,7 @@ public class ImportWALTest {
                     mock(Session.class),
                     null,
                     null,
-                    new ImportWAL.WALReplayer.ReplayDecisionController((java.io.Console) null))
+                    new ImportWAL.WALReplayer.ReplayDecisionController((Console) null))
                 .replay(entry));
   }
 
@@ -692,6 +693,418 @@ public class ImportWALTest {
     assertEquals(
         ImportWAL.WALReplayer.ReplayDecision.TERMINATE,
         ImportWAL.WALReplayer.ReplayDecisionController.parseDecision("q", true));
+  }
+
+  /**
+   * A real table-delete WAL must execute one SQL per table and become deletable only on success.
+   */
+  @Test
+  public void testReplayTableDeleteAsSql() throws Exception {
+    final File walFile = createWALFile(0);
+    writeWAL(
+        walFile,
+        tableDeleteEntry(
+            tableDeletion("table1", new TagPredicate.SegmentExactMatch("a", 1), 10, 20),
+            tableDeletion("table1", new TagPredicate.SegmentExactMatch(null, 2), 30, 40)));
+    final Session tree = mock(Session.class);
+    final Session table = mock(Session.class);
+    final SessionDataSet schema = mockTableSchema(table, "table1", "ts", "tag1", "tag2");
+    final ImportWAL.ReplayStatistics statistics =
+        ImportWAL.replayWALFiles(
+            Collections.singletonList(walFile.toPath()),
+            new ImportWAL.WALReplayer(
+                tree,
+                table,
+                "target_db",
+                (entry, executable) -> {
+                  assertTrue(executable);
+                  return ReplayDecision.EXECUTE;
+                }),
+            null,
+            true);
+
+    verify(table)
+        .executeNonQueryStatement(
+            "DELETE FROM \"table1\" WHERE (((\"tag1\" = 'a') AND (\"ts\" >= 10) AND (\"ts\" <= 20)) OR ((\"tag2\" IS NULL) AND (\"ts\" >= 30) AND (\"ts\" <= 40)))");
+    verify(schema).close();
+    verifyZeroInteractions(tree);
+    assertEquals(1, statistics.getReplayedOperationCount());
+    assertEquals(0, statistics.getSkippedEntryCount());
+    assertFalse(walFile.exists());
+  }
+
+  /**
+   * A node spanning tables emits one DELETE per table and reuses DESCRIBE metadata on later nodes.
+   */
+  @Test
+  public void testReplayTableDeleteGroupsTablesAndCachesSchema() throws Exception {
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    mockTableSchema(table, "table2", "time", "tag1");
+    final ImportWAL.WALReplayer replayer =
+        new ImportWAL.WALReplayer(
+            mock(Session.class), table, "target_db", (entry, executable) -> ReplayDecision.EXECUTE);
+    final WALEntry entry =
+        tableDeleteEntry(
+            tableDeletion("table1", new TagPredicate.NOP(), 10, 20),
+            tableDeletion("table2", new TagPredicate.NOP(), 10, 20));
+    assertEquals(ReplayResult.REPLAYED, replayer.replay(entry));
+    assertEquals(ReplayResult.REPLAYED, replayer.replay(entry));
+    verify(table, times(2))
+        .executeNonQueryStatement(
+            "DELETE FROM \"table1\" WHERE ((\"time\" >= 10) AND (\"time\" <= 20))");
+    verify(table, times(2))
+        .executeNonQueryStatement(
+            "DELETE FROM \"table2\" WHERE ((\"time\" >= 10) AND (\"time\" <= 20))");
+    verify(table).executeQueryStatement("DESCRIBE \"table1\"");
+    verify(table).executeQueryStatement("DESCRIBE \"table2\"");
+  }
+
+  /** SKIP/SKIP_ALL and quit must avoid all table RPCs, even if no target database was supplied. */
+  @Test
+  public void testReplayTableDeleteDecisionsBeforeSchemaLookup() throws Exception {
+    final WALEntry entry =
+        tableDeleteEntry(tableDeletion("table1", new TagPredicate.NOP(), 10, 20));
+    final Session table = mock(Session.class);
+    for (final ReplayDecision decision :
+        Arrays.asList(ReplayDecision.SKIP, ReplayDecision.SKIP_ALL)) {
+      assertEquals(
+          ReplayResult.SKIPPED,
+          new ImportWAL.WALReplayer(
+                  mock(Session.class), table, "target_db", (ignored, executable) -> decision)
+              .replay(entry));
+      assertEquals(
+          ReplayResult.SKIPPED,
+          new ImportWAL.WALReplayer(
+                  mock(Session.class), null, null, (ignored, executable) -> decision)
+              .replay(entry));
+    }
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new ImportWAL.WALReplayer(
+                    mock(Session.class),
+                    table,
+                    "target_db",
+                    (ignored, executable) -> ReplayDecision.TERMINATE)
+                .replay(entry));
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new ImportWAL.WALReplayer(
+                    mock(Session.class),
+                    table,
+                    "target_db",
+                    new ReplayDecisionController((Console) null))
+                .replay(entry));
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new ImportWAL.WALReplayer(
+                    mock(Session.class),
+                    null,
+                    null,
+                    (ignored, executable) -> ReplayDecision.EXECUTE)
+                .replay(entry));
+    verifyZeroInteractions(table);
+  }
+
+  /**
+   * Empty device sets represent no pending deletion and must never send an unconditional DELETE.
+   */
+  @Test
+  public void testReplayEmptyTableDelete() throws Exception {
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    final ImportWAL.WALReplayer replayer =
+        new ImportWAL.WALReplayer(
+            mock(Session.class), table, "target_db", (entry, executable) -> ReplayDecision.EXECUTE);
+    assertEquals(
+        ReplayResult.IGNORED,
+        replayer.replay(
+            tableDeleteEntry(
+                tableDeletion(
+                    "table1", new TagPredicate.DeviceIn(Collections.emptySet()), 10, 20))));
+    assertEquals(ReplayResult.IGNORED, replayer.replay(tableDeleteEntry()));
+    verify(table, never()).executeNonQueryStatement(any());
+  }
+
+  /**
+   * Quitting the conversion fallback must retain the entire WAL without executing earlier tables.
+   */
+  @Test
+  public void testTableDeletePrevalidationRetainsSource() throws Exception {
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    mockTableSchema(table, "table2", "time", "tag1");
+    final TableDeletionEntry columnDelete =
+        new TableDeletionEntry(
+            new DeletionPredicate(
+                "table2", new TagPredicate.NOP(), Collections.singletonList("s1")),
+            new TimeRange(10, 20));
+    final List<TableDeletionEntry> invalidEntries =
+        Arrays.asList(
+            columnDelete,
+            tableDeletion("table2", new TagPredicate.SegmentExactMatch("a", 2), 10, 20));
+    for (int i = 0; i < invalidEntries.size(); i++) {
+      final File walFile = createWALFile(i);
+      writeWAL(
+          walFile,
+          tableDeleteEntry(
+              tableDeletion("table1", new TagPredicate.NOP(), 10, 20), invalidEntries.get(i)));
+      final byte[] original = Files.readAllBytes(walFile.toPath());
+      final AtomicInteger prompts = new AtomicInteger();
+      final ImportWAL.WALReplayer replayer =
+          new ImportWAL.WALReplayer(
+              mock(Session.class),
+              table,
+              "target_db",
+              new ReplayDecisionController(
+                  (prompt, argument) -> {
+                    prompts.incrementAndGet();
+                    return argument instanceof WALEntryType ? "a" : "q";
+                  }));
+      assertThrows(
+          IOException.class,
+          () ->
+              ImportWAL.replayWALFiles(
+                  Collections.singletonList(walFile.toPath()), replayer, null, true));
+      assertArrayEquals(original, Files.readAllBytes(walFile.toPath()));
+      assertEquals(2, prompts.get());
+    }
+    verify(table, never()).executeNonQueryStatement(any());
+  }
+
+  /** Skipping an unconvertible node retains its WAL and lets serial replay finish later entries. */
+  @Test
+  public void testSkipUnconvertibleTableDeleteRetainsSource() throws Exception {
+    assertSkipUnconvertibleTableDeletes("s", false);
+  }
+
+  /** Skip-all for conversion failures must not skip subsequent convertible table deletes. */
+  @Test
+  public void testSkipAllUnconvertibleTableDeletesRetainsSources() throws Exception {
+    assertSkipUnconvertibleTableDeletes("l", false);
+  }
+
+  /** Parallel workers must preserve skipped nodes while deleting only completely replayed WALs. */
+  @Test
+  public void testParallelSkipUnconvertibleTableDeleteRetainsSource() throws Exception {
+    assertSkipUnconvertibleTableDeletes("s", true);
+  }
+
+  /** Parallel workers share one unsupported skip-all choice independently of table execute-all. */
+  @Test
+  public void testParallelSkipAllUnconvertibleTableDeletesRetainsSources() throws Exception {
+    assertSkipUnconvertibleTableDeletes("l", true);
+  }
+
+  private void assertSkipUnconvertibleTableDeletes(final String answer, final boolean parallel)
+      throws Exception {
+    final Path root = temporaryFolder.newFolder("conversion-wals").toPath();
+    final Path nodeA = Files.createDirectory(root.resolve("node-a"));
+    final Path nodeB = Files.createDirectory(root.resolve("node-b"));
+    final Path columnWAL = createWALFile(nodeA, 0);
+    final Path incompatibleWAL = createWALFile(nodeB, 0);
+    final Path completeWAL = createWALFile(nodeA, 1);
+    final TableDeletionEntry valid = tableDeletion("table1", new TagPredicate.NOP(), 10, 20);
+    final TableDeletionEntry columnDelete =
+        new TableDeletionEntry(
+            new DeletionPredicate(
+                "table2", new TagPredicate.NOP(), Collections.singletonList("s1")),
+            new TimeRange(10, 20));
+    final WALEntry insert = new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.d1", 1));
+    // Even the convertible part of a mixed node must not execute when the user skips the node.
+    writeWAL(columnWAL.toFile(), tableDeleteEntry(valid, columnDelete), insert);
+    writeWAL(
+        incompatibleWAL.toFile(),
+        tableDeleteEntry(
+            valid, tableDeletion("table2", new TagPredicate.SegmentExactMatch("a", 2), 10, 20)),
+        insert);
+    writeWAL(completeWAL.toFile(), tableDeleteEntry(valid));
+    final byte[] columnBytes = Files.readAllBytes(columnWAL);
+    final byte[] incompatibleBytes = Files.readAllBytes(incompatibleWAL);
+    final Session tree = mock(Session.class);
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    mockTableSchema(table, "table2", "time", "tag1");
+    final AtomicInteger executePrompts = new AtomicInteger();
+    final List<String> skipReasons = new CopyOnWriteArrayList<>();
+    final ReplayDecisionController controller =
+        new ReplayDecisionController(
+            (prompt, argument) -> {
+              if (argument instanceof WALEntryType) {
+                executePrompts.incrementAndGet();
+                return "a";
+              }
+              assertEquals(
+                  ImportWALMessages
+                      .MESSAGE_UNSUPPORTED_WAL_OPERATION_ARG_CHOOSE_S_SKIP_L_SKIP_ALL_Q_QUIT_0A734E52,
+                  prompt);
+              skipReasons.add((String) argument);
+              return answer;
+            });
+    final List<Path> files = ImportWAL.collectWALFiles(root);
+    final ImportWAL.ReplayStatistics statistics =
+        parallel
+            ? ImportWAL.replayWALDirectories(
+                files,
+                2,
+                () -> new ImportWAL.WALReplayer(tree, table, "target_db", controller),
+                null,
+                true)
+            : ImportWAL.replayWALFiles(
+                files, new ImportWAL.WALReplayer(tree, table, "target_db", controller), null, true);
+    assertArrayEquals(columnBytes, Files.readAllBytes(columnWAL));
+    assertArrayEquals(incompatibleBytes, Files.readAllBytes(incompatibleWAL));
+    assertFalse(Files.exists(completeWAL));
+    assertEquals(3, statistics.getReplayedOperationCount());
+    assertEquals(2, statistics.getSkippedEntryCount());
+    assertEquals(3, statistics.getCompletedFileCount());
+    assertEquals(1, executePrompts.get());
+    assertEquals("l".equals(answer) ? 1 : 2, skipReasons.size());
+    final List<String> expectedReasons =
+        Arrays.asList(
+            String.format(
+                ImportWALMessages
+                    .EXCEPTION_CANNOT_REPLAY_COLUMN_SPECIFIC_DELETION_FOR_TABLE_ARG_AS_DELETE_FROM_4A7ACC93,
+                "table2"),
+            String.format(
+                ImportWALMessages
+                    .EXCEPTION_CANNOT_REPLAY_TABLE_DELETION_TAG_SEGMENT_INDEX_ARG_IS_INCOMPATIBLE_WITH_TARGET_TABLE_ARG_D5E3CCEE,
+                2,
+                "table2"));
+    assertTrue(expectedReasons.containsAll(skipReasons));
+    verify(table).executeNonQueryStatement(any());
+    verify(tree, times(2)).insertTablet(any(Tablet.class));
+  }
+
+  /** Missing interaction and attempts to execute an unconvertible delete must still terminate. */
+  @Test
+  public void testUnconvertibleTableDeleteRequiresSkipChoice() throws Exception {
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    final WALEntry entry =
+        tableDeleteEntry(
+            tableDeletion("table1", new TagPredicate.SegmentExactMatch("a", 2), 10, 20));
+    for (final String answer : Arrays.asList(null, "e", "a")) {
+      final AtomicInteger prompts = new AtomicInteger();
+      final ReplayDecisionController controller =
+          new ReplayDecisionController(
+              (prompt, argument) -> {
+                prompts.incrementAndGet();
+                return argument instanceof WALEntryType ? "a" : answer;
+              });
+      assertThrows(
+          StatementExecutionException.class,
+          () ->
+              new ImportWAL.WALReplayer(mock(Session.class), table, "target_db", controller)
+                  .replay(entry));
+      assertEquals(2, prompts.get());
+    }
+    verify(table, never()).executeNonQueryStatement(any());
+  }
+
+  /** DESCRIBE RPC errors must abort import rather than being offered as skippable conversions. */
+  @Test
+  public void testTableDeleteSchemaFailureDoesNotOfferSkip() throws Exception {
+    for (final Exception failure :
+        Arrays.asList(
+            new StatementExecutionException("describe failed"),
+            new IoTDBConnectionException("disconnected"))) {
+      final Session table = mock(Session.class);
+      when(table.executeQueryStatement(any())).thenThrow(failure);
+      final AtomicInteger prompts = new AtomicInteger();
+      final ImportWAL.WALReplayer replayer =
+          new ImportWAL.WALReplayer(
+              mock(Session.class),
+              table,
+              "target_db",
+              (entry, executable) -> {
+                assertTrue(executable);
+                prompts.incrementAndGet();
+                return ReplayDecision.EXECUTE;
+              });
+      assertEquals(
+          failure,
+          assertThrows(
+              Exception.class,
+              () ->
+                  replayer.replay(
+                      tableDeleteEntry(tableDeletion("table1", new TagPredicate.NOP(), 10, 20)))));
+      assertEquals(1, prompts.get());
+      verify(table, never()).executeNonQueryStatement(any());
+    }
+  }
+
+  /** DELETE RPC failures cannot be skipped and must retain even previously completed WAL files. */
+  @Test
+  public void testTableDeleteExecutionFailureRetainsAllSources() throws Exception {
+    final File insertFile = createWALFile(0);
+    final File deleteFile = createWALFile(1);
+    writeWAL(insertFile, new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.d1", 1)));
+    writeWAL(deleteFile, tableDeleteEntry(tableDeletion("table1", new TagPredicate.NOP(), 10, 20)));
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    doThrow(new StatementExecutionException("delete failed"))
+        .when(table)
+        .executeNonQueryStatement(any());
+    final ImportWAL.WALReplayer replayer =
+        new ImportWAL.WALReplayer(
+            mock(Session.class),
+            table,
+            "target_db",
+            (entry, executable) -> {
+              assertTrue(executable);
+              return ReplayDecision.EXECUTE;
+            });
+    assertThrows(
+        IOException.class,
+        () ->
+            ImportWAL.replayWALFiles(
+                Arrays.asList(insertFile.toPath(), deleteFile.toPath()), replayer, null, true));
+    assertTrue(insertFile.exists());
+    assertTrue(deleteFile.exists());
+  }
+
+  /**
+   * Shared workers remember table execute-all independently of tree skip-all and unsupported skips.
+   */
+  @Test
+  public void testDeleteDecisionControllerSeparatesModelsAcrossWorkers() throws Exception {
+    final AtomicInteger prompts = new AtomicInteger();
+    final ReplayDecisionController controller =
+        new ReplayDecisionController(
+            (prompt, type) -> {
+              prompts.incrementAndGet();
+              return type == WALEntryType.RELATIONAL_DELETE_DATA_NODE ? "a" : "l";
+            });
+    final Session tree = mock(Session.class);
+    final Session table = mock(Session.class);
+    mockTableSchema(table, "table1", "time", "tag1");
+    final ImportWAL.WALReplayer first =
+        new ImportWAL.WALReplayer(tree, table, "target_db", controller);
+    final ImportWAL.WALReplayer second =
+        new ImportWAL.WALReplayer(tree, table, "target_db", controller);
+    final WALEntry treeDelete =
+        new WALInfoEntry(
+            1,
+            new DeleteDataNode(
+                new PlanNodeId(""),
+                Collections.singletonList(new MeasurementPath("root.sg.d1.s1")),
+                10,
+                20));
+    final WALEntry tableDelete =
+        tableDeleteEntry(tableDeletion("table1", new TagPredicate.NOP(), 10, 20));
+    assertEquals(ReplayResult.SKIPPED, first.replay(treeDelete));
+    assertEquals(ReplayResult.SKIPPED, first.replay(mockUnsupportedEntry()));
+    assertEquals(ReplayResult.REPLAYED, first.replay(tableDelete));
+    assertEquals(ReplayResult.SKIPPED, second.replay(treeDelete));
+    assertEquals(ReplayResult.SKIPPED, second.replay(mockUnsupportedEntry()));
+    assertEquals(ReplayResult.REPLAYED, second.replay(tableDelete));
+    assertEquals(3, prompts.get());
+    verify(table, times(2)).executeNonQueryStatement(any());
+    verifyZeroInteractions(tree);
   }
 
   /** Covers a non-aligned snapshot whose measurements have independent time axes. */
@@ -905,8 +1318,41 @@ public class ImportWALTest {
 
   private static WALEntry mockUnsupportedEntry() {
     final WALEntry entry = mock(WALEntry.class);
-    when(entry.getType()).thenReturn(WALEntryType.RELATIONAL_DELETE_DATA_NODE);
-    when(entry.getValue()).thenReturn(mock(RelationalDeleteDataNode.class));
+    when(entry.getType()).thenReturn(WALEntryType.OBJECT_FILE_NODE);
+    when(entry.getValue()).thenReturn(mock(ObjectNode.class));
     return entry;
+  }
+
+  private static WALEntry tableDeleteEntry(final TableDeletionEntry... entries) {
+    return new WALInfoEntry(
+        1, new RelationalDeleteDataNode(new PlanNodeId(""), Arrays.asList(entries), "source_db"));
+  }
+
+  private static TableDeletionEntry tableDeletion(
+      final String table, final TagPredicate predicate, final long start, final long end) {
+    return new TableDeletionEntry(
+        new DeletionPredicate(table, predicate), new TimeRange(start, end));
+  }
+
+  private static SessionDataSet mockTableSchema(
+      final Session session, final String table, final String timeColumn, final String... tags)
+      throws Exception {
+    final SessionDataSet dataSet = mock(SessionDataSet.class);
+    when(session.executeQueryStatement("DESCRIBE " + ImportWAL.WALReplayer.quoteIdentifier(table)))
+        .thenReturn(dataSet);
+    when(dataSet.iterator())
+        .thenAnswer(
+            ignored -> {
+              final SessionDataSet.DataIterator iterator = mock(SessionDataSet.DataIterator.class);
+              final AtomicInteger row = new AtomicInteger(-1);
+              when(iterator.next()).thenAnswer(call -> row.incrementAndGet() <= tags.length);
+              when(iterator.getString(1))
+                  .thenAnswer(call -> row.get() == 0 ? timeColumn : tags[row.get() - 1]);
+              when(iterator.getString(2))
+                  .thenAnswer(call -> row.get() == 0 ? "TIMESTAMP" : "STRING");
+              when(iterator.getString(3)).thenAnswer(call -> row.get() == 0 ? "TIME" : "TAG");
+              return iterator;
+            });
+    return dataSet;
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/ImportWALTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.tools;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.ContinuousSameSearchIndexSeparatorNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.ObjectNode;
@@ -28,6 +29,8 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalDe
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.RelationalInsertTabletNode;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.PrimitiveMemTable;
+import org.apache.iotdb.db.storageengine.dataregion.modification.DeletionPredicate;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.WALTestUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryType;
@@ -39,12 +42,15 @@ import org.apache.iotdb.db.storageengine.dataregion.wal.io.WALWriter;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALByteBufferForTest;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileStatus;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileUtils;
+import org.apache.iotdb.db.tools.ImportWAL.ReplayResult;
+import org.apache.iotdb.db.tools.ImportWAL.WALReplayer.ReplayDecision;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.StringArrayDeviceID;
+import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 import org.apache.tsfile.write.schema.MeasurementSchema;
@@ -251,6 +257,90 @@ public class ImportWALTest {
     assertFalse(secondWALFile.exists());
   }
 
+  /** Serial replay must retain tree/table deletes skipped with SKIP and delete complete WALs. */
+  @Test
+  public void testReplayRetainsSourceFilesWithSkippedDataEntries() throws Exception {
+    assertReplayRetainsSkippedSourceFiles(ReplayDecision.SKIP, false);
+  }
+
+  /** SKIP_ALL must preserve the same source files as SKIP during serial replay. */
+  @Test
+  public void testReplayRetainsSourceFilesWithSkipAllDataEntries() throws Exception {
+    assertReplayRetainsSkippedSourceFiles(ReplayDecision.SKIP_ALL, false);
+  }
+
+  /** Parallel workers must retain skipped data without preventing deletion of complete WALs. */
+  @Test
+  public void testParallelReplayRetainsSourceFilesWithSkippedDataEntries() throws Exception {
+    assertReplayRetainsSkippedSourceFiles(ReplayDecision.SKIP, true);
+  }
+
+  /** SKIP_ALL must preserve data skipped by either worker during directory-level replay. */
+  @Test
+  public void testParallelReplayRetainsSourceFilesWithSkipAllDataEntries() throws Exception {
+    assertReplayRetainsSkippedSourceFiles(ReplayDecision.SKIP_ALL, true);
+  }
+
+  private void assertReplayRetainsSkippedSourceFiles(
+      final ReplayDecision decision, final boolean parallel) throws Exception {
+    final Path source = temporaryFolder.newFolder("skip-wal-root").toPath();
+    final Path nodeA = Files.createDirectory(source.resolve("node-a"));
+    final Path nodeB = Files.createDirectory(source.resolve("node-b"));
+    final Path treeDeleteWAL = createWALFile(nodeA, 0);
+    final Path completeWAL = createWALFile(nodeA, 1);
+    final Path tableDeleteWAL = createWALFile(nodeB, 0);
+    final DeleteDataNode treeDelete =
+        new DeleteDataNode(
+            new PlanNodeId(""), List.of(new MeasurementPath("root.sg.d1.s1")), 10, 20);
+    final RelationalDeleteDataNode tableDelete =
+        new RelationalDeleteDataNode(
+            new PlanNodeId(""),
+            new TableDeletionEntry(new DeletionPredicate("table1"), new TimeRange(10, 20)),
+            "db");
+    final WALInfoEntry insert = new WALInfoEntry(1, WALTestUtils.getInsertRowNode("root.sg.d1", 1));
+    // A later successful insert must not hide an earlier skip in the same file, and skips must
+    // not prevent deletion of a fully replayed file in the same directory.
+    writeWAL(treeDeleteWAL.toFile(), new WALInfoEntry(1, treeDelete), insert);
+    writeWAL(tableDeleteWAL.toFile(), insert, new WALInfoEntry(1, tableDelete));
+    // Signals, separators, and empty snapshots carry no pending data and remain deletable.
+    writeWAL(
+        completeWAL.toFile(),
+        insert,
+        new WALSignalEntry(WALEntryType.CLOSE_SIGNAL),
+        new WALSignalEntry(WALEntryType.ROLL_WAL_LOG_WRITER_SIGNAL),
+        new WALInfoEntry(1, new ContinuousSameSearchIndexSeparatorNode()),
+        new WALInfoEntry(1, new PrimitiveMemTable()));
+    final byte[] treeDeleteBytes = Files.readAllBytes(treeDeleteWAL);
+    final byte[] tableDeleteBytes = Files.readAllBytes(tableDeleteWAL);
+    final Session session = mock(Session.class);
+    final List<Path> walFiles = ImportWAL.collectWALFiles(source);
+    final ImportWAL.ReplayStatistics statistics =
+        parallel
+            ? ImportWAL.replayWALDirectories(
+                walFiles,
+                2,
+                () ->
+                    new ImportWAL.WALReplayer(session, null, null, (entry, treeModel) -> decision),
+                null,
+                true)
+            : ImportWAL.replayWALFiles(
+                walFiles,
+                new ImportWAL.WALReplayer(session, null, null, (entry, treeModel) -> decision),
+                null,
+                true);
+
+    assertTrue(Files.exists(treeDeleteWAL));
+    assertTrue(Files.exists(tableDeleteWAL));
+    assertArrayEquals(treeDeleteBytes, Files.readAllBytes(treeDeleteWAL));
+    assertArrayEquals(tableDeleteBytes, Files.readAllBytes(tableDeleteWAL));
+    assertFalse(Files.exists(completeWAL));
+    assertEquals(3, statistics.getReplayedOperationCount());
+    assertEquals(6, statistics.getSkippedEntryCount());
+    assertEquals(3, statistics.getCompletedFileCount());
+    verify(session, times(3)).insertTablet(any(Tablet.class));
+    verify(session, never()).deleteData(any(), anyLong(), anyLong());
+  }
+
   /** Covers all-or-nothing replay gating: a later failure must retain every source WAL file. */
   @Test
   public void testReplayRetainsAllSourceFilesWhenAnyFileFails() throws Exception {
@@ -425,6 +515,7 @@ public class ImportWALTest {
         .deleteData(eq(Arrays.asList("root.sg.d1.s1", "root.sg.d2.*")), eq(10L), eq(20L));
   }
 
+  /** A skipped tree delete must be distinguished from a control entry that needs no replay. */
   @Test
   public void testReplayTreeDeleteSkipsAfterConfirmation() throws Exception {
     final DeleteDataNode deleteNode =
@@ -432,7 +523,7 @@ public class ImportWALTest {
             new PlanNodeId(""), List.of(new MeasurementPath("root.sg.d1.s1")), 10, 20);
     final Session treeSession = mock(Session.class);
 
-    final boolean replayed =
+    final ReplayResult result =
         new ImportWAL.WALReplayer(
                 treeSession,
                 null,
@@ -440,10 +531,11 @@ public class ImportWALTest {
                 (entry, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.SKIP)
             .replay(new WALInfoEntry(1, deleteNode));
 
-    assertFalse(replayed);
+    assertEquals(ReplayResult.SKIPPED, result);
     verify(treeSession, never()).deleteData(any(), anyLong(), anyLong());
   }
 
+  /** Execute-all replays deletes; skip-all reports skipped data for each affected worker. */
   @Test
   public void testReplayTreeDeleteExecuteAllAndSkipAllDecisions() throws Exception {
     final DeleteDataNode deleteNode =
@@ -461,8 +553,10 @@ public class ImportWALTest {
     final ImportWAL.WALReplayer secondExecuteAllReplayer =
         new ImportWAL.WALReplayer(treeSession, null, null, executeAllPrompt);
 
-    assertTrue(firstExecuteAllReplayer.replay(new WALInfoEntry(1, deleteNode)));
-    assertTrue(secondExecuteAllReplayer.replay(new WALInfoEntry(2, deleteNode)));
+    assertEquals(
+        ReplayResult.REPLAYED, firstExecuteAllReplayer.replay(new WALInfoEntry(1, deleteNode)));
+    assertEquals(
+        ReplayResult.REPLAYED, secondExecuteAllReplayer.replay(new WALInfoEntry(2, deleteNode)));
     assertEquals(2, executeAllPromptCount.get());
     verify(treeSession, times(2)).deleteData(any(), eq(10L), eq(20L));
 
@@ -478,8 +572,10 @@ public class ImportWALTest {
     final ImportWAL.WALReplayer secondSkipAllReplayer =
         new ImportWAL.WALReplayer(skippedTreeSession, null, null, skipAllPrompt);
 
-    assertFalse(firstSkipAllReplayer.replay(new WALInfoEntry(1, deleteNode)));
-    assertFalse(secondSkipAllReplayer.replay(new WALInfoEntry(2, deleteNode)));
+    assertEquals(
+        ReplayResult.SKIPPED, firstSkipAllReplayer.replay(new WALInfoEntry(1, deleteNode)));
+    assertEquals(
+        ReplayResult.SKIPPED, secondSkipAllReplayer.replay(new WALInfoEntry(2, deleteNode)));
     assertEquals(2, skipAllPromptCount.get());
     verify(skippedTreeSession, never()).deleteData(any(), anyLong(), anyLong());
   }
@@ -506,7 +602,7 @@ public class ImportWALTest {
   public void testReplayUnsupportedEntrySkipsAfterConfirmation() throws Exception {
     final WALEntry entry = mockUnsupportedEntry();
 
-    final boolean replayed =
+    final ReplayResult result =
         new ImportWAL.WALReplayer(
                 mock(Session.class),
                 null,
@@ -514,9 +610,10 @@ public class ImportWALTest {
                 (ignored, treeDelete) -> ImportWAL.WALReplayer.ReplayDecision.SKIP)
             .replay(entry);
 
-    assertFalse(replayed);
+    assertEquals(ReplayResult.SKIPPED, result);
   }
 
+  /** Table deletes and ObjectNode entries skipped with SKIP_ALL must both retain their WALs. */
   @Test
   public void testReplayUnsupportedEntriesSkipAllAfterConfirmation() throws Exception {
     final AtomicInteger promptCount = new AtomicInteger();
@@ -528,15 +625,15 @@ public class ImportWALTest {
     final ImportWAL.WALReplayer relationalDeleteReplayer =
         new ImportWAL.WALReplayer(mock(Session.class), null, null, skipAllPrompt);
 
-    assertFalse(relationalDeleteReplayer.replay(mockUnsupportedEntry()));
-    assertFalse(relationalDeleteReplayer.replay(mockUnsupportedEntry()));
+    assertEquals(ReplayResult.SKIPPED, relationalDeleteReplayer.replay(mockUnsupportedEntry()));
+    assertEquals(ReplayResult.SKIPPED, relationalDeleteReplayer.replay(mockUnsupportedEntry()));
 
     final WALEntry objectEntry = mock(WALEntry.class);
     when(objectEntry.getType()).thenReturn(WALEntryType.OBJECT_FILE_NODE);
     when(objectEntry.getValue()).thenReturn(mock(ObjectNode.class));
     final ImportWAL.WALReplayer objectNodeReplayer =
         new ImportWAL.WALReplayer(mock(Session.class), null, null, skipAllPrompt);
-    assertFalse(objectNodeReplayer.replay(objectEntry));
+    assertEquals(ReplayResult.SKIPPED, objectNodeReplayer.replay(objectEntry));
     assertEquals(3, promptCount.get());
   }
 
@@ -696,18 +793,18 @@ public class ImportWALTest {
     assertEquals(1, tabletCaptor.getAllValues().get(1).getRowSize());
   }
 
-  /** Covers a signal snapshot, which carries no user data and must be skipped. */
+  /** A signal snapshot carries no user data and must not prevent deletion of its source WAL. */
   @Test
   public void testReplaySignalMemTableSnapshotIsSkipped() throws Exception {
     final IMemTable signalMemTable = mock(IMemTable.class);
     when(signalMemTable.isSignalMemTable()).thenReturn(true);
     final Session treeSession = mock(Session.class);
 
-    final boolean replayed =
+    final ReplayResult result =
         new ImportWAL.WALReplayer(treeSession, null, null)
             .replay(new WALInfoEntry(1, signalMemTable));
 
-    assertFalse(replayed);
+    assertEquals(ReplayResult.IGNORED, result);
     verify(treeSession, never()).insertTablet(any(Tablet.class));
     verify(treeSession, never()).insertAlignedTablet(any(Tablet.class));
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/TableWALDeleteConverterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/TableWALDeleteConverterTest.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.tools;
+
+import org.apache.iotdb.commons.schema.table.TsTable;
+import org.apache.iotdb.commons.schema.table.column.TagColumnSchema;
+import org.apache.iotdb.commons.schema.table.column.TimeColumnSchema;
+import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.common.QueryId;
+import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Delete;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
+import org.apache.iotdb.db.storageengine.dataregion.modification.DeletionPredicate;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TagPredicate;
+import org.apache.iotdb.rpc.StatementExecutionException;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.file.metadata.StringArrayDeviceID;
+import org.apache.tsfile.read.common.TimeRange;
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class TableWALDeleteConverterTest {
+
+  private static final List<String> TAGS = Arrays.asList("tag1", "tag2");
+  private static final long[] TIMES = {
+    Long.MIN_VALUE,
+    Long.MIN_VALUE + 1,
+    -11,
+    -10,
+    -1,
+    0,
+    9,
+    10,
+    20,
+    21,
+    30,
+    40,
+    41,
+    Long.MAX_VALUE - 1,
+    Long.MAX_VALUE
+  };
+
+  /**
+   * OR must preserve each device filter's own inclusive interval instead of mixing their ranges.
+   */
+  @Test
+  public void testMergeDisjointRanges() throws Exception {
+    assertEquivalent(
+        "table1",
+        "time",
+        TAGS,
+        Arrays.asList(
+            entry(new TagPredicate.SegmentExactMatch("a", 1), 10, 20),
+            entry(new TagPredicate.SegmentExactMatch("b", 1), 30, 40)),
+        sampleDevices());
+  }
+
+  /** Every serialized TAG predicate must survive SQL parsing and deletion analysis unchanged. */
+  @Test
+  public void testTagPredicateRoundTrip() throws Exception {
+    final List<TagPredicate> predicates =
+        Arrays.asList(
+            new TagPredicate.NOP(),
+            new TagPredicate.SegmentExactMatch("a", 1),
+            new TagPredicate.SegmentExactMatch(null, 2),
+            new TagPredicate.SegmentNotNull(2),
+            new TagPredicate.FullExactMatch(device("table1", "a", "x")),
+            new TagPredicate.DeviceIn(
+                Arrays.asList(device("table1", "a"), device("table1", "b", "x"))),
+            new TagPredicate.And(
+                new TagPredicate.SegmentExactMatch("table1", 0),
+                new TagPredicate.And(
+                    new TagPredicate.NOP(), new TagPredicate.SegmentExactMatch("a", 1)),
+                new TagPredicate.SegmentNotNull(2)),
+            new TagPredicate.SegmentNotNull(0));
+    for (final TagPredicate predicate : predicates) {
+      assertEquivalent(
+          "table1",
+          "time",
+          TAGS,
+          Collections.singletonList(entry(predicate, -10, 20)),
+          sampleDevices());
+    }
+  }
+
+  /**
+   * An exact device with trimmed trailing nulls must not also delete devices with non-null TAGs.
+   */
+  @Test
+  public void testExactDeviceWithTrailingNullTags() throws Exception {
+    for (final IDeviceID device : Arrays.asList(device("table1", "a"), device("table1"))) {
+      assertEquivalent(
+          "table1",
+          "time",
+          TAGS,
+          Collections.singletonList(
+              entry(new TagPredicate.FullExactMatch(device), Long.MIN_VALUE, Long.MAX_VALUE)),
+          sampleDevices());
+    }
+  }
+
+  /**
+   * Empty device sets and mismatching table-name segments must never become unqualified DELETEs.
+   */
+  @Test
+  public void testEmptyPredicates() throws Exception {
+    final TableWALDeleteConverter converter = new TableWALDeleteConverter("table1", "time", TAGS);
+    assertNull(converter.toSql(Collections.emptyList()));
+    for (final TagPredicate predicate :
+        Arrays.asList(
+            new TagPredicate.DeviceIn(Collections.emptySet()),
+            new TagPredicate.SegmentExactMatch("other", 0),
+            new TagPredicate.And(
+                new TagPredicate.NOP(), new TagPredicate.DeviceIn(Collections.emptySet())))) {
+      assertNull(converter.toSql(Collections.singletonList(entry(predicate, 10, 20))));
+      assertEquivalent(
+          "table1",
+          "time",
+          TAGS,
+          Arrays.asList(
+              entry(predicate, 10, 20), entry(new TagPredicate.SegmentExactMatch("b", 1), 30, 40)),
+          sampleDevices());
+    }
+  }
+
+  /**
+   * Full-range and tagless deletions omit WHERE instead of emitting unsupported boolean literals.
+   */
+  @Test
+  public void testUnboundedAndTaglessDeletes() throws Exception {
+    final List<TableDeletionEntry> entries =
+        Collections.singletonList(entry(new TagPredicate.NOP(), Long.MIN_VALUE, Long.MAX_VALUE));
+    assertEquals(
+        "DELETE FROM \"table1\"",
+        new TableWALDeleteConverter("table1", "time", TAGS).toSql(entries));
+    assertEquivalent("table1", "time", TAGS, entries, sampleDevices());
+    assertEquivalent(
+        "table1",
+        "time",
+        Collections.emptyList(),
+        Collections.singletonList(entry(new TagPredicate.FullExactMatch(device("table1")), 10, 20)),
+        Collections.singletonList(device("table1")));
+  }
+
+  /** Inclusive long endpoints, negative timestamps, and renamed TIME columns must remain exact. */
+  @Test
+  public void testTimeBoundariesAndRenamedTimeColumn() throws Exception {
+    for (final long[] range :
+        new long[][] {
+          {Long.MIN_VALUE, Long.MIN_VALUE},
+          {Long.MAX_VALUE, Long.MAX_VALUE},
+          {Long.MIN_VALUE, -10},
+          {-10, Long.MAX_VALUE},
+          {-10, -1},
+          {0, 0}
+        }) {
+      assertEquivalent(
+          "table1",
+          "ts",
+          TAGS,
+          Collections.singletonList(entry(new TagPredicate.NOP(), range[0], range[1])),
+          sampleDevices());
+    }
+  }
+
+  /** Identifiers and values containing SQL punctuation must remain literal names and TAG values. */
+  @Test
+  public void testQuotedIdentifiersAndValues() throws Exception {
+    final String table = "ta\"ble;1";
+    final String value = "a' OR '1'='1; -- \\ 中文\n";
+    assertEquivalent(
+        table,
+        "event\"time",
+        Arrays.asList("tag\"name", "select"),
+        Collections.singletonList(
+            new TableDeletionEntry(
+                new DeletionPredicate(table, new TagPredicate.SegmentExactMatch(value, 1)),
+                new TimeRange(10, 20))),
+        Arrays.asList(device(table, value), device(table, "a"), device(table)));
+  }
+
+  /**
+   * A later column tombstone must be rejected even after an earlier predicate matches every row.
+   */
+  @Test
+  public void testRejectColumnSpecificDeletion() {
+    final TableDeletionEntry columnDelete =
+        new TableDeletionEntry(
+            new DeletionPredicate(
+                "table1", new TagPredicate.NOP(), Collections.singletonList("field1")),
+            new TimeRange(10, 20));
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new TableWALDeleteConverter("table1", "time", TAGS)
+                .toSql(
+                    Arrays.asList(
+                        entry(new TagPredicate.NOP(), Long.MIN_VALUE, Long.MAX_VALUE),
+                        columnDelete)));
+  }
+
+  /**
+   * Incompatible TAG indices/devices and missing TIME metadata must fail instead of widening SQL.
+   */
+  @Test
+  public void testRejectIncompatibleSchema() {
+    final List<TagPredicate> predicates =
+        Arrays.asList(
+            new TagPredicate.SegmentExactMatch("a", -1),
+            new TagPredicate.SegmentExactMatch(null, 3),
+            new TagPredicate.SegmentNotNull(3),
+            new TagPredicate.FullExactMatch(device("other", "a")),
+            new TagPredicate.FullExactMatch(device("table1", "a", "b", "c")),
+            new TagPredicate.DeviceIn(Collections.singletonList(device("other", "a"))));
+    for (final TagPredicate predicate : predicates) {
+      assertThrows(
+          StatementExecutionException.class,
+          () ->
+              new TableWALDeleteConverter("table1", "time", TAGS)
+                  .toSql(Collections.singletonList(entry(predicate, 10, 20))));
+    }
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new TableWALDeleteConverter("table1", null, TAGS)
+                .toSql(Collections.singletonList(entry(new TagPredicate.NOP(), 10, 20))));
+  }
+
+  /** A newly introduced or unknown predicate must fail until its SQL semantics are implemented. */
+  @Test
+  public void testRejectUnsupportedPredicate() {
+    assertThrows(
+        StatementExecutionException.class,
+        () ->
+            new TableWALDeleteConverter("table1", "time", TAGS)
+                .toSql(Collections.singletonList(entry(mock(TagPredicate.class), 10, 20))));
+  }
+
+  private static TableDeletionEntry entry(
+      final TagPredicate predicate, final long start, final long end) {
+    return new TableDeletionEntry(
+        new DeletionPredicate("table1", predicate), new TimeRange(start, end));
+  }
+
+  private static IDeviceID device(final String... segments) {
+    return new StringArrayDeviceID(segments);
+  }
+
+  private static List<IDeviceID> sampleDevices() {
+    final List<IDeviceID> devices = new ArrayList<>();
+    for (final String first : Arrays.asList(null, "a", "b")) {
+      for (final String second : Arrays.asList(null, "x", "y")) {
+        devices.add(device("table1", first, second));
+      }
+    }
+    return devices;
+  }
+
+  private static void assertEquivalent(
+      final String tableName,
+      final String timeColumn,
+      final List<String> tags,
+      final List<TableDeletionEntry> original,
+      final List<IDeviceID> devices)
+      throws Exception {
+    final String sql = new TableWALDeleteConverter(tableName, timeColumn, tags).toSql(original);
+    final Delete delete = (Delete) new SqlParser().createStatement(sql, ZoneOffset.UTC, null);
+    assertEquals(tableName, delete.getTable().getName().getSuffix());
+    final TsTable table = new TsTable(tableName);
+    table.addColumnSchema(new TimeColumnSchema(timeColumn, TSDataType.TIMESTAMP));
+    for (final String tag : tags) {
+      table.addColumnSchema(new TagColumnSchema(tag, TSDataType.STRING));
+    }
+    final List<TableDeletionEntry> parsed =
+        AnalyzeUtils.parseExpressions2ModEntries(
+            delete.getWhere().orElse(null),
+            table,
+            "target_db",
+            new MPPQueryContext(new QueryId("1")));
+    for (final IDeviceID device : devices) {
+      for (final long time : TIMES) {
+        assertEquals(
+            sql + "; device=" + device + "; time=" + time,
+            original.stream().anyMatch(entry -> entry.affects(device, time, time)),
+            parsed.stream().anyMatch(entry -> entry.affects(device, time, time)));
+      }
+    }
+  }
+}

--- a/scripts/tools/import-wal.sh
+++ b/scripts/tools/import-wal.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if [ -z "${IOTDB_INCLUDE}" ]; then
+  :
+elif [ -r "$IOTDB_INCLUDE" ]; then
+  . "$IOTDB_INCLUDE"
+fi
+
+if [ -z "${IOTDB_HOME}" ]; then
+  export IOTDB_HOME="$(cd "$(dirname "$0")"/..; pwd)"
+fi
+
+if [ -n "$JAVA_HOME" ]; then
+  for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
+    if [ -x "$java" ]; then
+      JAVA="$java"
+      break
+    fi
+  done
+else
+  JAVA=java
+fi
+
+if [ -z "$JAVA" ]; then
+  echo "Unable to find java executable. Check JAVA_HOME and PATH environment variables." > /dev/stderr
+  exit 1
+fi
+
+JVM_OPTS="-Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8"
+CLASSPATH="${IOTDB_HOME}/lib/*"
+MAIN_CLASS=org.apache.iotdb.db.tools.ImportWAL
+
+"$JAVA" $JVM_OPTS -DIOTDB_HOME="${IOTDB_HOME}" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+exit $?

--- a/scripts/tools/windows/import-wal.bat
+++ b/scripts/tools/windows/import-wal.bat
@@ -1,0 +1,43 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
+@echo off
+if "%OS%" == "Windows_NT" setlocal
+
+pushd %~dp0..\..
+if NOT DEFINED IOTDB_HOME set IOTDB_HOME=%CD%
+popd
+
+if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.db.tools.ImportWAL
+if NOT DEFINED JAVA_HOME goto :err
+
+set JAVA_OPTS=-ea^
+ -DIOTDB_HOME="%IOTDB_HOME%" -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8
+set CLASSPATH="%IOTDB_HOME%\lib\*"
+
+"%JAVA_HOME%\bin\java" %JAVA_OPTS% -cp %CLASSPATH% %MAIN_CLASS% %*
+set ret_code=%ERRORLEVEL%
+goto finally
+
+:err
+echo JAVA_HOME environment variable must be set!
+set ret_code=1
+
+:finally
+ENDLOCAL & EXIT /B %ret_code%


### PR DESCRIPTION
## Summary
- add the `import-wal` tool for replaying tree/table model WAL files and MemTable snapshots into a target IoTDB instance
- support `thread_num` parallel replay by WAL directory and `on_success` source WAL handling
- add interactive decisions for tree-model deletes and safe skip/terminate handling for unsupported table-model deletes and `ObjectNode` entries
- include Linux/Windows launchers, localized messages, WAL boundary handling, and unit coverage

## Validation
- `mvn test -pl iotdb-core/datanode -Dtest=ImportWALTest -DfailIfNoTests=false`
- `mvn test-compile -pl iotdb-core/datanode -Pwith-zh-locale -DskipTests`
- Spotless, Checkstyle, and `git diff --check`
