### PR TITLE
[Subscription] Add consensus subscription Grafana dashboard

### DIFF
--- a/example/subscription/grafana/README.md
+++ b/example/subscription/grafana/README.md
@@ -1,0 +1,156 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# Consensus subscription Grafana dashboard
+
+This directory contains a standalone Grafana dashboard and example Prometheus alert rules for
+IoTConsensus-based subscriptions. The dashboard uses only metrics exposed by Apache IoTDB and does
+not contain environment-specific datasource UIDs, hosts, ports, or credentials.
+
+## Scope and limitations
+
+The dashboard answers these operational questions with the metrics currently available:
+
+- Is a subscription queue active and initialized for every DataRegion?
+- Is the queue caught up after a stopped workload?
+- Is work waiting in memory or behind the WAL cursor?
+- Are consumers receiving bytes?
+- Did WAL retention make search indexes unavailable?
+- Did a seek or routing-epoch change occur?
+
+The dashboard does **not** provide an exact remaining event count, a reliable ETA, or a
+subscription-progress CLI. In a continuously written incremental topic there is no final
+completion time. The subscription_consensus_lag
+metric is an approximate queue-local work indicator: it includes queued, in-flight, pending,
+realtime-buffered, and lingered entries, but all unread WAL work adds
+only one unit regardless of how many WAL entries remain. The watermark is the maximum observed data
+timestamp, not committed progress.
+
+The potential-no-delivery signal means that an active, initialized queue has approximate work but
+its cumulative response-byte counter has not increased for the alert window. It can identify a
+stopped or non-polling consumer, but it cannot prove that ACK/commit progress is stalled because no
+committed-progress timestamp or counter is currently exported.
+
+## Prerequisites
+
+Enable the DataNode Prometheus reporter at IMPORTANT level in iotdb-system.properties and restart
+the DataNode:
+
+~~~properties
+dn_metric_reporter_list=PROMETHEUS
+dn_metric_level=IMPORTANT
+dn_metric_prometheus_reporter_port=9092
+~~~
+
+If subscription has been disabled explicitly, also set subscription_enabled=true.
+
+Configure Prometheus to scrape the /metrics endpoint of every DataNode. For example:
+
+~~~yaml
+scrape_configs:
+  - job_name: iotdb-datanode
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - datanode-1:9092
+          - datanode-2:9092
+          - datanode-3:9092
+~~~
+
+Consensus subscription series exist only while a record-handler incremental subscription queue is
+registered. Create and poll a subscription before treating an empty query as a scrape failure. The
+legacy topic value mode=consensus is normalized to mode=incremental.
+
+Verify a DataNode directly before importing the dashboard:
+
+~~~shell
+curl http://datanode-1:9092/metrics | grep -E '^subscription_(consensus|event|uncommitted)'
+~~~
+
+At minimum, a running consensus subscription should expose subscription_consensus_lag,
+subscription_consensus_active, subscription_consensus_initialized, and the other metrics listed
+below. Prometheus must also add its normal instance label during scraping.
+
+## Import
+
+1. In Grafana, select **Dashboards > New > Import**.
+2. Upload consensus-subscription-dashboard.json.
+3. Select the Prometheus datasource requested by DS_PROMETHEUS.
+4. Select cluster, instance, queue, and DataRegion variables.
+
+The queue label is currently exported as name=<consumerGroupId>_<topicName>. It identifies a
+consumer-group/topic queue, not an individual consumer, and the underscore encoding can be
+ambiguous when both names contain underscores.
+
+## Metric semantics
+
+| Metric | Dashboard interpretation |
+| --- | --- |
+| subscription_consensus_lag | Approximate work, not an exact remaining count |
+| subscription_uncommitted_event_count | Delivered in-flight events awaiting commit |
+| subscription_event_transfer_total (no `rate` label) | Cumulative response bytes |
+| subscription_event_transfer_total{rate="m1"} | One-minute response transfer rate in bytes/second |
+| subscription_consensus_wal_gap | Cumulative unavailable WAL search indexes skipped |
+| subscription_consensus_routing_epoch_change | Cumulative routing epoch changes |
+| subscription_consensus_watermark | Maximum observed data timestamp in the server timestamp precision |
+| subscription_consensus_seek_generation | Seek/reset generation; it is not a commit ID |
+| subscription_consensus_active | 1 on the preferred-writer queue and 0 on inactive replicas |
+| subscription_consensus_initialized | 1 after the queue runtime is initialized and 0 while dormant |
+
+For a stopped workload, a region is heuristically caught up when its preferred-writer queue is
+active, initialized, and has lag equal to zero. Completion of a bounded workload requires every
+participating region to satisfy that condition. This heuristic must not be presented as completion
+or ETA for an unbounded incremental stream.
+
+## Example alerts
+
+consensus-subscription-alert-rules.yml contains Prometheus rule examples for:
+
+- newly skipped WAL indexes;
+- no active preferred-writer queue for a group/topic/region;
+- an active queue that remains dormant while work is pending;
+- pending work with no response bytes transferred for ten minutes.
+
+The last alert is deliberately named NoDelivery rather than StalledCommit. Tune its duration to the
+consumer poll interval and expected workload. Add a deployment-specific absent-series alert only
+when an external inventory says that a subscription must exist; absent series alone can also mean
+that no consensus subscription is configured.
+
+Validate the rules before loading them:
+
+~~~shell
+promtool check rules consensus-subscription-alert-rules.yml
+~~~
+
+## Suggested live validation
+
+1. Start all DataNodes and confirm Prometheus up is 1 for their metric endpoints.
+2. Run either ConsensusSubscriptionSessionExample or
+   ConsensusTableModelSubscriptionSessionExample.
+3. Confirm every expected queue/region has series and exactly one active replica.
+4. Write a finite batch, keep polling and committing, and confirm the active initialized queues
+   return to approximate lag zero after writes stop.
+5. Stop the consumer, write more data, and confirm pending work remains while the cumulative
+   response-byte counter stops increasing and the NoDelivery alert eventually fires.
+6. Restart or transfer the region leader and confirm a new active replica appears without duplicate
+   active queues.
+7. Confirm WAL gap remains zero in normal operation. Any increase is a data-loss diagnostic and
+   should be investigated immediately.

--- a/example/subscription/grafana/consensus-subscription-alert-rules.yml
+++ b/example/subscription/grafana/consensus-subscription-alert-rules.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+groups:
+  - name: iotdb-consensus-subscription
+    interval: 30s
+    rules:
+      - alert: IoTDBConsensusSubscriptionWALGapIncreased
+        expr: increase(subscription_consensus_wal_gap{nodeType="DATANODE"}[5m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: Consensus subscription skipped unavailable WAL indexes
+          description: >-
+            Queue {{ $labels.name }} in DataRegion {{ $labels.region }} on
+            {{ $labels.instance }} skipped WAL search indexes during the last five minutes.
+
+      - alert: IoTDBConsensusSubscriptionNoActiveQueue
+        expr: max by (cluster, name, region) (subscription_consensus_active{nodeType="DATANODE"}) == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Consensus subscription has no active preferred-writer queue
+          description: >-
+            Queue {{ $labels.name }} in DataRegion {{ $labels.region }} has had no active
+            preferred-writer replica for five minutes.
+
+      - alert: IoTDBConsensusSubscriptionDormantWithPendingWork
+        expr: |-
+          (subscription_consensus_active{nodeType="DATANODE"} == 1)
+            and
+          (subscription_consensus_initialized{nodeType="DATANODE"} == 0)
+            and
+          (subscription_consensus_lag{nodeType="DATANODE"} > 0)
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Active consensus subscription queue is dormant with pending work
+          description: >-
+            Queue {{ $labels.name }} in DataRegion {{ $labels.region }} on
+            {{ $labels.instance }} is active but uninitialized while approximate work remains.
+
+      - alert: IoTDBConsensusSubscriptionNoDelivery
+        expr: |-
+          (subscription_consensus_active{nodeType="DATANODE"} == 1)
+            and
+          (subscription_consensus_initialized{nodeType="DATANODE"} == 1)
+            and
+          (subscription_consensus_lag{nodeType="DATANODE"} > 0)
+            and
+          (increase(subscription_event_transfer_total{nodeType="DATANODE",rate!~".+"}[5m]) == 0)
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Consensus subscription has pending work but transfers no response bytes
+          description: >-
+            Queue {{ $labels.name }} in DataRegion {{ $labels.region }} on
+            {{ $labels.instance }} has approximate pending work but no response bytes have been
+            increased for at least ten minutes. Check whether a consumer is polling and healthy.

--- a/example/subscription/grafana/consensus-subscription-dashboard.json
+++ b/example/subscription/grafana/consensus-subscription-dashboard.json
@@ -1,0 +1,1021 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource containing the IoTDB DataNode metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of queue replica series currently exported. Zero can mean that no consensus subscription queue is registered; it is not by itself a scrape failure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "replica series",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Replica Series",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Preferred-writer queues, aggregated with max across replicas. A value of one means one active queue for the selected group/topic and region; it is not a consumer count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(max by (cluster,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"}))",
+          "legendFormat": "active queues",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Preferred-Writer Queues",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Approximate queue-local work on active replicas. It is not an exact remaining event count: unread WAL work contributes only a presence unit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum((subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"}) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1))",
+          "legendFormat": "approximate lag",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Approximate Pending Work",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Delivered events that are currently in flight and awaiting commit. This is not the total backlog.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum((subscription_uncommitted_event_count{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"}) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1))",
+          "legendFormat": "uncommitted",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Uncommitted Events",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Heuristic count of active replicas that are initialized and have approximate lag equal to zero. Use only after a bounded workload has stopped writing; it is not a completion proof for a live stream.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(((subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_initialized{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1)) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 0))",
+          "legendFormat": "caught-up regions",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Caught-Up Regions (Heuristic)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Potential no-delivery queues: active and initialized with approximate work, while the cumulative response-byte counter has not increased for five minutes. This does not prove commit progress is stalled.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum((((subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} > 0) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1)) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_initialized{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1)) and on (cluster,nodeType,nodeId,instance,name,region) (increase(subscription_event_transfer_total{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\",rate!~\".+\"}[5m]) == 0))",
+          "legendFormat": "potential no-delivery",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Potential No-Delivery Queues (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Approximate queue-local work on the active preferred-writer replica. A return to zero after writes stop is a useful heuristic, not an exact backlog measurement.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"}) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1)",
+          "legendFormat": "{{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Approximate Lag by Region",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Events delivered but not yet committed on the active queue. A sustained value can indicate slow processing or commit handling, but no commit-stall timestamp is exported.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(subscription_uncommitted_event_count{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"}) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1)",
+          "legendFormat": "{{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Uncommitted Events by Region",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "One-minute moving response transfer rate in bytes per second. The metric is response bytes, not event count or operations per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(subscription_event_transfer_total{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\",rate=\"m1\"}) and on (cluster,nodeType,nodeId,instance,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"} == 1)",
+          "legendFormat": "{{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Response Transfer Rate (bytes/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Active and initialized are queue lifecycle indicators. Active is one on the preferred-writer queue and zero on inactive replicas; initialized means the runtime has been initialized.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster,name,region) (subscription_consensus_active{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "active {{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster,name,region) (subscription_consensus_initialized{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "initialized {{name}} / {{region}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Lifecycle Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Cumulative diagnostics. WAL gap counts unavailable WAL search indexes skipped by the queue; routing epoch changes indicate ownership or route transitions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster,name,region) (subscription_consensus_wal_gap{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "WAL gap {{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster,name,region) (subscription_consensus_routing_epoch_change{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "routing changes {{name}} / {{region}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "WAL and Routing Diagnostics",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Maximum observed data timestamp, expressed in the server timestamp precision. It is not a committed frontier and should not be unconditionally formatted as milliseconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster,name,region) (subscription_consensus_watermark{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "{{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Watermark (Observed Timestamp)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Seek or reset generation. It is a diagnostic generation number, not a commit ID or an exact consumer offset.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster,name,region) (subscription_consensus_seek_generation{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\",region=~\"$region\"})",
+          "legendFormat": "{{name}} / {{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Seek / Reset Generation",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 14,
+      "options": {
+        "content": "### Reading this dashboard\n\n`subscription_consensus_lag` is an approximate queue-local work indicator, not an exact remaining event count. For a bounded workload, active + initialized + lag=0 across every participating region is only a catch-up heuristic after writes stop. A continuously written incremental stream has no final ETA. The `NoDelivery` signal detects pending work with no increase in response bytes; it cannot prove that ACK/commit progress is stalled. The legacy topic value `mode=consensus` is normalized to the current `mode=incremental` value.",
+        "mode": "markdown"
+      },
+      "title": "Interpretation and Limits",
+      "type": "text"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "iotdb",
+    "subscription",
+    "consensus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\"}, cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\"}, name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Queue (group/topic)",
+        "multi": true,
+        "name": "queue",
+        "options": [],
+        "query": {
+          "query": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\"}, name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\"}, region)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "DataRegion",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": {
+          "query": "label_values(subscription_consensus_lag{nodeType=\"DATANODE\",cluster=~\"$cluster\",instance=~\"$instance\",name=~\"$queue\"}, region)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "15s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Apache IoTDB Consensus Subscription",
+  "uid": null,
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Description

Add a standalone Grafana dashboard and Prometheus alert-rule example for IoTConsensus-based subscriptions.

The dashboard:

- filters by cluster, DataNode instance, consumer-group/topic queue, and DataRegion;
- shows queue replicas, preferred-writer activity, initialization, approximate lag, uncommitted events, and response-byte transfer;
- surfaces WAL-gap, routing-epoch, watermark, and seek/reset diagnostics;
- documents the metric semantics and provides operational validation steps.

The alert examples cover skipped WAL indexes, missing active preferred-writer queues, dormant queues with pending work, and pending work with no response-byte delivery.

The dashboard intentionally does not claim an exact remaining event count, ETA, or authoritative commit-stall status. `subscription_consensus_lag` is an approximate queue-local work indicator, and the current metrics do not expose a precise backlog or a progress CLI. The `NoDelivery` alert is therefore a consumer-delivery diagnostic, not proof of stalled ACK/commit progress. The legacy `mode=consensus` value is documented as normalized to `mode=incremental`.

This PR targets `apache/iotdb:master`; it is not based on 2.0.11.1 or a Timecho branch.

## Verification

- Parsed `consensus-subscription-dashboard.json` with PowerShell `ConvertFrom-Json`.
- Parsed `consensus-subscription-alert-rules.yml` with SnakeYAML 2.6.
- Checked dashboard panel-ID uniqueness and datasource placeholders.
- Checked that dashboard and alert PromQL expressions use `nodeType=DATANODE`.
- Checked all referenced subscription metric names against the latest `origin/master` metric definitions.
- Ran `git diff --cached --check`.
- `promtool` was not installed in the local environment, so `promtool check rules` could not be run.

No Java source or runtime behavior is changed by this PR.