### PR TITLE
Fix degraded time index migration IT memory proportions

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/batch/IoTDBRegionMigrateNormalITForIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/batch/IoTDBRegionMigrateNormalITForIoTV2BatchIT.java
@@ -53,7 +53,7 @@ public class IoTDBRegionMigrateNormalITForIoTV2BatchIT
   @Test
   public void migrateRegionWithDegradedTimeIndexTest() throws Exception {
     // set TsFileResource memory to 0 to trigger degrading
-    EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0");
+    EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0:1:1");
 
     successTest(1, 1, 1, 2, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
 


### PR DESCRIPTION
Backport #18337 to `rc/2.0.11`.

The degraded time index migration IT still uses the legacy 8-component query memory proportion, while the branch includes the 9-component query memory configuration with a dedicated subscription component. Update the test configuration to include the subscription proportion so the IT allocates memory consistently with the runtime configuration.

Cherry-picked commit:
- `343acc440f` Fix region migration IT memory proportions (#18337)

Validation:
- `mvn -pl integration-test -P with-integration-tests spotless:check -DskipTests`
- `mvn -pl integration-test -am -P with-integration-tests test-compile -DskipTests`
