### PR TITLE
Fix snapshot pipe startup before IoTConsensus catch-up

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -812,6 +812,15 @@ public class IoTConsensusServerImpl {
     }
   }
 
+  /** Wait until every remote peer has synchronized its writes to all peers. */
+  public void waitUntilAllRemotePeersSyncLogCompleted() throws ConsensusGroupModifyPeerException {
+    for (Peer peer : getConfiguration()) {
+      if (!peer.equals(thisNode)) {
+        waitTargetPeerUntilSyncLogCompleted(peer);
+      }
+    }
+  }
+
   public boolean hasReleaseAllRegionRelatedResource(ConsensusGroupId groupId) {
     return stateMachine.hasReleaseAllRegionRelatedResource(groupId);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
@@ -27,6 +27,10 @@ import org.apache.iotdb.commons.pipe.datastructure.pattern.IoTDBTreePatternOpera
 import org.apache.iotdb.commons.pipe.datastructure.pattern.TreePattern;
 import org.apache.iotdb.commons.pipe.source.IoTDBSource;
 import org.apache.iotdb.commons.queryengine.common.SqlDialect;
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.iot.IoTConsensus;
+import org.apache.iotdb.consensus.iot.IoTConsensusServerImpl;
+import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.i18n.DataNodePipeMessages;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.metric.overview.PipeDataNodeSinglePipeMetrics;
@@ -536,10 +540,12 @@ public class IoTDBDataRegionSource extends IoTDBSource {
         historicalSource.getClass().getSimpleName(),
         realtimeSource.getClass().getSimpleName());
 
+    final DataRegionId dataRegionIdObject = new DataRegionId(this.regionId);
+    waitUntilAllRemotePeersSyncLogCompletedIfNecessary(dataRegionIdObject);
+
     super.start();
 
     final AtomicReference<Exception> exceptionHolder = new AtomicReference<>(null);
-    final DataRegionId dataRegionIdObject = new DataRegionId(this.regionId);
     while (true) {
       // try to start sources in the data region ...
       // first try to run if data region exists, then try to run if data region does not exist.
@@ -595,6 +601,28 @@ public class IoTDBDataRegionSource extends IoTDBSource {
           historicalSource.getClass().getSimpleName(),
           realtimeSource.getClass().getSimpleName(),
           e);
+    }
+  }
+
+  private void waitUntilAllRemotePeersSyncLogCompletedIfNecessary(final DataRegionId dataRegionId)
+      throws Exception {
+    // A heartbeat-only source cannot capture writes that arrive after historical scanning. Before
+    // starting that scan, wait for every remote IoTConsensus writer to finish applying its pending
+    // writes to this local replica. This method must be called without holding the DataRegion write
+    // lock because applying a remote write may need the same lock.
+    if (!(realtimeSource instanceof PipeRealtimeDataRegionHeartbeatSource)) {
+      return;
+    }
+
+    final IConsensus dataRegionConsensus = DataRegionConsensusImpl.getInstance();
+    if (!(dataRegionConsensus instanceof IoTConsensus)) {
+      return;
+    }
+
+    final IoTConsensusServerImpl consensusServer =
+        ((IoTConsensus) dataRegionConsensus).getImpl(dataRegionId);
+    if (consensusServer != null) {
+      consensusServer.waitUntilAllRemotePeersSyncLogCompleted();
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeSubtaskExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeSubtaskExecutorTest.java
@@ -26,8 +26,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public abstract class PipeSubtaskExecutorTest {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeSubtaskExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeSubtaskExecutorTest.java
@@ -26,8 +26,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 public abstract class PipeSubtaskExecutorTest {
@@ -71,12 +71,7 @@ public abstract class PipeSubtaskExecutorTest {
     // test start a subtask which is in the map
     executor.register(subtask);
     executor.start(subtask.getTaskID());
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-    verify(subtask, atLeast(2)).call();
+    verify(subtask, timeout(10_000).atLeast(2)).call();
     Assert.assertTrue(subtask.isSubmittingSelf());
 
     // test start a subtask which is in the map and is already running


### PR DESCRIPTION
## Description

Snapshot/history-only Pipe sources use a heartbeat-only realtime source. With IoTConsensus, a Pipe task can start on a replica before writes from another writer have been asynchronously applied. The historical scan then sees no TsFiles, emits its terminate event, and allows the Pipe to be auto-dropped before the delayed writes arrive.

This change waits for all remote IoTConsensus writers to finish synchronizing their logs before a heartbeat-only DataRegion source begins historical extraction. The wait runs outside the DataRegion write lock so remote writes can still be applied. Other consensus protocols and realtime Pipe source modes retain the existing startup path.

## Verification

- `mvn spotless:apply -pl iotdb-core/consensus,iotdb-core/datanode`
- Consensus module compilation passed
- DataNode full-module compilation is blocked locally by unrelated stale dependency/generated-source errors