### PR TITLE
Fix pipe historical extraction when device metadata is unavailable

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
@@ -1012,7 +1012,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
               .getDeviceIsAlignedMapFromCache(resource.getTsFile(), false);
       deviceSet =
           Objects.nonNull(deviceIsAlignedMap) ? deviceIsAlignedMap.keySet() : resource.getDevices();
-    } catch (final IOException e) {
+    } catch (final IOException | RuntimeException e) {
       LOGGER.warn(
           DataNodePipeMessages.PIPE_FAILED_TO_GET_DEVICES_FROM_TSFILE_1,
           pipeName,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSourceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSourceTest.java
@@ -31,12 +31,14 @@ import org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant;
 import org.apache.iotdb.commons.pipe.config.constant.SystemConstant;
 import org.apache.iotdb.commons.pipe.config.plugin.configuraion.PipeTaskRuntimeConfiguration;
 import org.apache.iotdb.commons.pipe.config.plugin.env.PipeTaskSourceRuntimeEnvironment;
+import org.apache.iotdb.commons.pipe.datastructure.pattern.PrefixTreePattern;
 import org.apache.iotdb.commons.pipe.datastructure.resource.PersistentResource;
 import org.apache.iotdb.commons.pipe.event.ProgressReportEvent;
 import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.pipe.consensus.ReplicateProgressDataNodeManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.FileTimeIndex;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
@@ -141,6 +143,30 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSourceTest {
       Assert.assertEquals(
           Arrays.asList(firstResource.getTsFilePath()), source.getSuppliedTsFiles());
       Assert.assertEquals(1, source.getPendingQueueSize());
+    } finally {
+      FileUtils.deleteFileOrDirectory(tempDir);
+    }
+  }
+
+  @Test
+  public void testMissingTsFileResourceDoesNotBlockHistoricalExtraction() throws Exception {
+    final PipeHistoricalDataRegionTsFileAndDeletionSource source =
+        new PipeHistoricalDataRegionTsFileAndDeletionSource();
+    final File tempDir = Files.createTempDirectory("pipeHistoricalMissingResource").toFile();
+
+    try {
+      final TsFileResource resource = createTsFileResource(tempDir, "missing-resource.tsfile");
+      resource.setTimeIndex(new FileTimeIndex());
+      setPrivateField(source, "pipeName", "pipe");
+      setPrivateField(source, "dataRegionId", 1);
+      setPrivateField(source, "treePattern", new PrefixTreePattern("root.**"));
+
+      final Method method =
+          PipeHistoricalDataRegionTsFileAndDeletionSource.class.getDeclaredMethod(
+              "mayTsFileResourceOverlappedWithPattern", TsFileResource.class);
+      method.setAccessible(true);
+
+      Assert.assertTrue((Boolean) method.invoke(source, resource));
     } finally {
       FileUtils.deleteFileOrDirectory(tempDir);
     }


### PR DESCRIPTION
## Problem

When a historical TsFile's `.resource` file is missing or unreadable, `TsFileResource.getDevices()` can throw a `RuntimeException`. The historical pipe source only caught `IOException`, so the file was skipped and the pipe could remain blocked waiting for historical extraction to complete.

## Solution

Treat runtime failures while reading device metadata the same as I/O failures: log the error and continue extracting the TsFile because it may match the configured pattern.

## Tests

- Manually compiled the changed production and test classes with javac.
- Ran `PipeHistoricalDataRegionTsFileAndDeletionSourceTest`: 20 tests passed.
- Added coverage for a missing `.tsfile.resource` with `FileTimeIndex`.