### PR TITLE
[DOC] Point the contributing documents section to apache/iotdb-docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,21 +61,17 @@ You can choose issue types: bug, improvement, new feature, etc.  New issues will
 
 ## Contributing documents
 
-The content of all IoTDB official websites is in the docs of the project root directory:
+The content of all IoTDB official websites lives in a separate repository,
+[apache/iotdb-docs](https://github.com/apache/iotdb-docs), under its `src` directory:
 
-* docs/SystemDesign: System Design Document-English Version
-* docs/zh/SystemDesign: System Design Document-Chinese Version
-* docs/UserGuide: User Guide English Version
-* docs/zh/UserGuide: User Guide Chinese Version
-* docs/Community: community English Version
-* docs/zh/Community: community Chinese Version
-* docs/Development: Development Guide English Version
-* docs/zh/Development: Development Guide Chinese Version
+* src/UserGuide: User Guide English Version
+* src/zh/UserGuide: User Guide Chinese Version
+* src/Community: community English Version
+* src/zh/Community: community Chinese Version
+* src/Development: Development Guide English Version
 
-Correspondence between versions and branches on the official website:
-
-* In progress -> master
-* major_version.x -> rel/major_version （eg 0.9.x -> rel/0.9）
+Documentation versions are organised as directories rather than branches, for example
+`src/UserGuide/V1.3.x`, `src/UserGuide/latest` and `src/UserGuide/Master`.
 
 Precautions:
 


### PR DESCRIPTION
## Description

The "Contributing documents" section of `CONTRIBUTING.md` describes a `docs/` directory that no longer exists in this repository, so a new contributor who wants to fix a documentation page has nowhere to go.

`git ls-tree -r --name-only HEAD | grep '^docs/'` returns nothing — the website content now lives in [apache/iotdb-docs](https://github.com/apache/iotdb-docs) (last pushed 2026-08-24), under its `src` directory.

Almost every line of that section is now inaccurate, so this PR updates it:

**Location.** `docs/...` → `apache/iotdb-docs`, `src/...`.

**Directory list.** I checked each path against `apache/iotdb-docs` rather than assuming the layout carried over:

| documented path | new path | exists? |
| --- | --- | --- |
| `docs/UserGuide` | `src/UserGuide` | yes |
| `docs/zh/UserGuide` | `src/zh/UserGuide` | yes |
| `docs/Community` | `src/Community` | yes |
| `docs/zh/Community` | `src/zh/Community` | yes |
| `docs/Development` | `src/Development` | yes |
| `docs/zh/Development` | — | **no** |
| `docs/SystemDesign` | — | **no** |
| `docs/zh/SystemDesign` | — | **no** |

The three that no longer exist are dropped from the list.

**Version mapping.** The section said versions map to branches (`In progress -> master`, `major_version.x -> rel/major_version`). `apache/iotdb-docs` has no `rel/*` branches — its only non-dependabot branches are `main` and `TableAuth` — and versions are directories instead: `src/UserGuide/` contains `Master`, `latest`, `latest-Table`, `V1.3.x`, `V1.2.x`, `V0.13.x`, `dev-1.3`. The text now says that.

The "Precautions" bullets below (image hosting in `iotdb-bin-resources`, Unicode and dollar-sign rules) still apply and are untouched.

## How I checked

Every path in the new list was resolved through the GitHub contents API against `apache/iotdb-docs`, and the branch list was read from the branches API. The absence of `docs/` here was confirmed with `git ls-tree` on the current `master` (`6aec4b8`) rather than by looking at a working copy.

I searched the issue tracker and open PRs first and did not find an existing report or anyone working on this, so there is no issue to reference. If one exists that I missed, I'm happy to link it.

_Disclosure: prepared with AI assistance; every path and branch above was verified against the live repositories._
