### PR TITLE
Fix stop-edge.sh not stopping its own process when IOTDB_HOME is set

### DIFF
--- a/scripts/sbin/start-edge.sh
+++ b/scripts/sbin/start-edge.sh
@@ -21,8 +21,16 @@
 # Start IoTDB Edge: ConfigNode + DataNode in one JVM process.
 
 if [ -z "${IOTDB_HOME}" ]; then
-    export IOTDB_HOME="$(cd "$(dirname "$0")"/.. && pwd)"
+    IOTDB_HOME="$(dirname "$0")/.."
 fi
+# Normalise to a physical absolute path. This value is handed to the JVM as
+# -DIOTDB_HOME and is what stop-edge.sh matches on, so it has to identify the
+# installation on its own, independently of the path used to launch.
+IOTDB_HOME_PHYSICAL="$(cd -P -- "${IOTDB_HOME}" 2>/dev/null && pwd -P)"
+if [ -n "${IOTDB_HOME_PHYSICAL}" ]; then
+    IOTDB_HOME="${IOTDB_HOME_PHYSICAL}"
+fi
+export IOTDB_HOME
 if [ -z "${IOTDB_CONF}" ]; then
     export IOTDB_CONF=${IOTDB_HOME}/conf
 fi

--- a/scripts/sbin/stop-edge.sh
+++ b/scripts/sbin/stop-edge.sh
@@ -24,10 +24,12 @@ if [ -z "${IOTDB_HOME}" ]; then
     IOTDB_HOME="$(cd "$(dirname "$0")"/.. && pwd)"
 fi
 
-# Resolve symlinks and relative segments so that the same installation reached
-# through a different path still compares equal.
+# Resolve to a physical absolute path so that the same installation reached
+# through a different path still compares equal. "cd -P" is required: a plain
+# "cd" collapses ".." logically, which would resolve "<symlink>/../x" against the
+# symlink's parent instead of its target.
 resolve_home() {
-    (cd "$1" 2>/dev/null && pwd -P) || printf '%s' "$1"
+    (cd -P -- "$1" 2>/dev/null && pwd -P) || printf '%s' "$1"
 }
 
 IOTDB_HOME_RESOLVED="$(resolve_home "${IOTDB_HOME}")"
@@ -44,10 +46,21 @@ is_same_edge_home() {
             ;;
     esac
     # Fall back to comparing resolved paths, so that a start-edge.sh invoked with
-    # IOTDB_HOME pointing at a symlink is still recognised here.
+    # IOTDB_HOME pointing at a symlink is still recognised here. The value is
+    # delimited by the next " -D", which start-edge.sh always emits after
+    # -DIOTDB_HOME. If a hand-built command line ends with -DIOTDB_HOME, the
+    # extraction keeps the trailing arguments, the resolution below fails and the
+    # process is simply not matched -- never matched to the wrong installation.
     local home="${command_line#*-DIOTDB_HOME=}"
     home="${home%% -D*}"
     [ -n "$home" ] && [ "$home" != "$command_line" ] || return 1
+    # Only absolute values can be resolved from here. A relative one such as "."
+    # is meaningful in the started process's working directory, not in ours, so
+    # resolving it here could match an unrelated installation.
+    case "$home" in
+        /*) ;;
+        *) return 1 ;;
+    esac
     [ "$(resolve_home "$home")" = "${IOTDB_HOME_RESOLVED}" ]
 }
 

--- a/scripts/sbin/stop-edge.sh
+++ b/scripts/sbin/stop-edge.sh
@@ -20,7 +20,17 @@
 
 # Stop IoTDB Edge (the merged ConfigNode + DataNode process).
 
-IOTDB_HOME="$(cd "$(dirname "$0")"/.. && pwd)"
+if [ -z "${IOTDB_HOME}" ]; then
+    IOTDB_HOME="$(cd "$(dirname "$0")"/.. && pwd)"
+fi
+
+# Resolve symlinks and relative segments so that the same installation reached
+# through a different path still compares equal.
+resolve_home() {
+    (cd "$1" 2>/dev/null && pwd -P) || printf '%s' "$1"
+}
+
+IOTDB_HOME_RESOLVED="$(resolve_home "${IOTDB_HOME}")"
 
 PID_FILE="${IOTDB_HOME}/edge.pid"
 
@@ -31,9 +41,14 @@ is_same_edge_home() {
             return 0
             ;;
         *)
-            return 1
             ;;
     esac
+    # Fall back to comparing resolved paths, so that a start-edge.sh invoked with
+    # IOTDB_HOME pointing at a symlink is still recognised here.
+    local home="${command_line#*-DIOTDB_HOME=}"
+    home="${home%% -D*}"
+    [ -n "$home" ] && [ "$home" != "$command_line" ] || return 1
+    [ "$(resolve_home "$home")" = "${IOTDB_HOME_RESOLVED}" ]
 }
 
 is_edge_process() {

--- a/scripts/sbin/stop-edge.sh
+++ b/scripts/sbin/stop-edge.sh
@@ -56,7 +56,9 @@ is_same_edge_home() {
     [ -n "$home" ] && [ "$home" != "$command_line" ] || return 1
     # Only absolute values can be resolved from here. A relative one such as "."
     # is meaningful in the started process's working directory, not in ours, so
-    # resolving it here could match an unrelated installation.
+    # resolving it here could match an unrelated installation. The emptiness check
+    # above matters for the same reason: "cd" succeeds on an empty argument and
+    # yields our own working directory.
     case "$home" in
         /*) ;;
         *) return 1 ;;


### PR DESCRIPTION
## Description

Fixes #18545.

`start-edge.sh` honours an `IOTDB_HOME` taken from the environment and passes that
value to the JVM as `-DIOTDB_HOME=...`. `stop-edge.sh` recomputed `IOTDB_HOME`
from its own location and matched the process command line against that string,
so when the two differed it declined to act on its own process, exited 0, and
removed the PID file. A service manager saw a successful stop while the process
kept running; the following `ExecStart` then found the ports occupied and also
exited 0, so a configuration change silently never took effect.

### The change

`stop-edge.sh` now honours `IOTDB_HOME` the same way `start-edge.sh` does, and
adds a resolved-path comparison as a fallback:

- the original literal comparison is tried first and is unchanged, so any command
  line that matched before still matches;
- only when it does not hit does the script extract the value of `-DIOTDB_HOME=`
  and compare it with `IOTDB_HOME` after resolving both with `cd ... && pwd -P`.

The change is additive: it can recognise more processes than before, never fewer.

### Behavioural note

This widens the identity test from "the same path string" to "the same resolved
directory", so two different symlinks pointing at one installation now count as
the same installation. That seems to be the intent of the check, but it is a
semantic change and worth a second opinion.

### Verification

Four start/stop environment combinations, each from a fresh extraction of the
packaged Edge archive, with `$ROOT/iotdb` symlinked to the install directory.
Every row was confirmed to have `10710` actually listening before the stop was
issued, so a row cannot pass by the process having died on its own:

```
start with IOTDB_HOME   stop with IOTDB_HOME   before          after
----------------------  ---------------------  --------------  --------------
symlink                 real path              still running   stopped
symlink                 unset                  still running   stopped
unset                   symlink                stopped         stopped
unset                   unset                  stopped         stopped
```

The two rows that fail before the change are exactly the ones where
`start-edge.sh` was given an `IOTDB_HOME` that differs from the path the script
derives.

Also re-ran the restart sequence from the issue after the change: the stop now
terminates the process, the following start comes up on the edited `dn_rpc_port`,
and the old port is released.

Built and run on macOS with JDK 22, from the packaged
`apache-iotdb-2.0.11-SNAPSHOT-edge-bin.zip`.

### Not changed

`scripts/sbin/windows/stop-edge.bat:23` sets `IOTDB_HOME` unconditionally while
`start-edge.bat:65` honours the environment, which is the same shape. I have no
Windows machine and did not run it, so I have left it alone rather than propose an
untested change.


---

### Update after review

`start-edge.sh` now normalises `IOTDB_HOME` to a physical absolute path before
exporting it, taking the first of the two options suggested in review. The
normalisation happens before every derived variable (`IOTDB_CONF`,
`IOTDB_DATA_HOME`, `IOTDB_LOG_DIR`, `CONFIGNODE_*`), before `-DIOTDB_HOME` is
built, and before the PID file path.

`stop-edge.sh` keeps the absolute-path guard in its fallback. That is not a
duplicate of the launcher change: a process started by an earlier `start-edge.sh`
during an upgrade can still carry a relative value on its command line, and those
should be left to the literal comparison rather than resolved against the stopping
shell's directory.

### Observable change

Normalising the path alters the string that appears in `ps` output, in the
start-up message and in the logs, so a monitor matching on the previous string
will need updating. The file locations themselves are unchanged, since the
symlink and the physical path resolve to the same directory.

The two problems raised in review, both of which could stop a process from a
different installation, are covered as regression cases:

```
scenario                                            base    previous  now
--------------------------------------------------  ------  --------  ------
[P1] -DIOTDB_HOME=. in A, stopped from B            keep    stopped   keep
[P2] home x/link/../edge, stopped from x/edge       keep    stopped   keep
[P2] home x/link/../edge, stopped from y/edge       -       -         stopped
symlink home, stopped from the real path            keep    stopped   stopped
```
