### PR TITLE
[To dev/1.3] Fix pipe historical extraction when device metadata is unavailable (#18541)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileSource.java
@@ -691,7 +691,7 @@ public class PipeHistoricalDataRegionTsFileSource implements PipeHistoricalDataR
               .getDeviceIsAlignedMapFromCache(resource.getTsFile(), false);
       deviceSet =
           Objects.nonNull(deviceIsAlignedMap) ? deviceIsAlignedMap.keySet() : resource.getDevices();
-    } catch (final IOException e) {
+    } catch (final IOException | RuntimeException e) {
       LOGGER.warn(
           "Pipe {}@{}: failed to get devices from TsFile {}, extract it anyway",
           pipeName,
@@ -714,7 +714,7 @@ public class PipeHistoricalDataRegionTsFileSource implements PipeHistoricalDataR
               .getDeviceIsAlignedMapFromCache(resource.getTsFile(), false);
       deviceSet =
           Objects.nonNull(deviceIsAlignedMap) ? deviceIsAlignedMap.keySet() : resource.getDevices();
-    } catch (final IOException e) {
+    } catch (final IOException | RuntimeException e) {
       return false;
     }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileSourceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileSourceTest.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.commons.pipe.event.ProgressReportEvent;
 import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.FileTimeIndex;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
@@ -407,6 +408,36 @@ public class PipeHistoricalDataRegionTsFileSourceTest {
                   source,
                   createClosedTsFileResource(
                       tempDir, "empty-device.tsfile", new SimpleProgressIndex(0, 1))));
+    } finally {
+      FileUtils.deleteFileOrDirectory(tempDir);
+    }
+  }
+
+  @Test
+  public void testMissingTsFileResourceDoesNotBlockHistoricalExtraction() throws Exception {
+    final File tempDir = Files.createTempDirectory("pipeHistoricalMissingResource").toFile();
+
+    try {
+      final PipeHistoricalDataRegionTsFileSource source =
+          new PipeHistoricalDataRegionTsFileSource();
+      final TsFileResource resource = createTsFileResource(tempDir, "missing-resource.tsfile");
+      resource.setTimeIndex(new FileTimeIndex());
+
+      setPrivateField(source, "pipeName", "pipe");
+      setPrivateField(source, "dataRegionId", 1);
+      setPrivateField(source, "pipePattern", new PrefixPipePattern("root.**"));
+
+      final Method mayOverlapMethod =
+          PipeHistoricalDataRegionTsFileSource.class.getDeclaredMethod(
+              "mayTsFileResourceOverlappedWithPattern", TsFileResource.class);
+      mayOverlapMethod.setAccessible(true);
+      Assert.assertTrue((Boolean) mayOverlapMethod.invoke(source, resource));
+
+      final Method coveredMethod =
+          PipeHistoricalDataRegionTsFileSource.class.getDeclaredMethod(
+              "isTsFileResourceCoveredByPattern", TsFileResource.class);
+      coveredMethod.setAccessible(true);
+      Assert.assertFalse((Boolean) coveredMethod.invoke(source, resource));
     } finally {
       FileUtils.deleteFileOrDirectory(tempDir);
     }


### PR DESCRIPTION
## Summary

Backport the historical pipe device-metadata handling fix from #18541.

When a .tsfile.resource sidecar is missing, FileTimeIndex.getDevices() can throw a RuntimeException. Treat the failure as unavailable device metadata during both historical file filtering and event creation so the pipe continues extracting instead of getting stuck.

The TsFile reference-race fix from #18376 is already present in dev/1.3 via #18544.

## Validation

- git diff --check
- Targeted Maven test attempted; this checkout lacks generated thrift classes required by the older branch.