### PR TITLE
Fix flaky PARTIAL/FINAL plan assertion in rateFunctionsNormalTest

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -36,6 +36,10 @@ import org.junit.runner.RunWith;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
@@ -5901,6 +5905,13 @@ public class IoTDBTableAggregationIT {
       try (ResultSet resultSet = statement.executeQuery("EXPLAIN (FORMAT JSON) " + query)) {
         Assert.assertTrue(resultSet.next());
         String plan = resultSet.getString(1);
+        // The PARTIAL/FINAL split only exists when the scanned data spans multiple DataRegions.
+        // Under randomized partition allocation (e.g. the SHUFFLE strategy used by
+        // IoTDBTableAggregation2IT), all devices may occasionally land in one single region,
+        // where a SINGLE-step aggregation is the correct plan, so the check must be skipped.
+        if (countDistinctRegionIds(plan) < 2) {
+          return;
+        }
         Assert.assertTrue(
             "Expected a PARTIAL aggregation in plan: " + plan, plan.contains("PARTIAL"));
         Assert.assertTrue("Expected a FINAL aggregation in plan: " + plan, plan.contains("FINAL"));
@@ -5908,6 +5919,15 @@ public class IoTDBTableAggregationIT {
     } catch (Exception exception) {
       throw new AssertionError(exception);
     }
+  }
+
+  private static int countDistinctRegionIds(String plan) {
+    Set<String> regionIds = new HashSet<>();
+    Matcher matcher = Pattern.compile("\"RegionId\"\\s*:\\s*\"(\\d+)\"").matcher(plan);
+    while (matcher.find()) {
+      regionIds.add(matcher.group(1));
+    }
+    return regionIds.size();
   }
 
   @Test


### PR DESCRIPTION
## Description

`IoTDBTableAggregation2IT.rateFunctionsNormalTest` (inherited from `IoTDBTableAggregationIT`) fails sporadically:

```
Expected a PARTIAL aggregation in plan: { ... "Step": "SINGLE" ... "RegionId": "3", "DeviceNumber": "8" ... }
```

### Root cause

`assertRateQueryUsesIntermediateAggregation` unconditionally requires the `EXPLAIN (FORMAT JSON)` output of an ungrouped `rate()/increase()/irate()/delta()` query over `rate_merge_test` to contain a `PARTIAL`/`FINAL` two-step aggregation. That split only exists when the scanned data spans more than one DataRegion.

`IoTDBTableAggregation2IT` runs with `data_partition_allocation_strategy = SHUFFLE`. `PartitionBalancer.shuffleAllocationStrategy` assigns each (seriesSlot, timeSlot) to a **random** DataRegionGroup, and all 8 rows of `rate_merge_test` fall into one time partition. So occasionally all 8 devices land in the same DataRegion; the planner then correctly produces a `SINGLE`-step aggregation with one `DeviceTableScanNode`, and the assertion fails even though both the plan and the query result are correct (the result comparison right before the assertion had already passed).

### Fix

Count the distinct `RegionId` values in the JSON plan first. Skip the `PARTIAL`/`FINAL` check when the plan scans fewer than two distinct regions (a `SINGLE` aggregation is the correct plan there), and keep asserting it whenever the data actually spans multiple regions — which preserves the original intent of the check in the deterministic base-class environment (`CUSTOM` extension policy with 2 DataRegions per DataNode).

### Verification

- `IoTDBTableAggregationIT#rateFunctionsNormalTest` and `IoTDBTableAggregation2IT#rateFunctionsNormalTest` pass locally (TableSimpleIT).
- The region-count regex was verified against the single-region failing plan shape (count 1 → skip), a multi-region shape (count 2 → assert), and `"RegionId": "Not Assigned"` (count 0 → skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
