### PR TITLE
[Subscription] Suppress pull commit progress error when subscription is disabled

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/subscription/PullCommitProgressRPCHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/subscription/PullCommitProgressRPCHandler.java
@@ -54,7 +54,8 @@ public class PullCommitProgressRPCHandler
     if (response.getStatus().getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       LOGGER.info(
           ConfigNodeMessages.SUCCESSFULLY_ON_DATANODE, requestType, formattedTargetLocation);
-    } else {
+    } else if (response.getStatus().getCode()
+        != TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode()) {
       LOGGER.error(
           ConfigNodeMessages.FAILED_TO_ON_DATANODE_RESPONSE,
           requestType,


### PR DESCRIPTION
## Description

When `subscription_enabled=false` on a DataNode, `pullCommitProgress` returns `UNSUPPORTED_OPERATION` (status code 300). The ConfigNode handler now treats this expected response as a silent no-op instead of emitting an error log. Other failures continue to be logged at error level.

## Tests

- `mvn spotless:apply -pl iotdb-core/confignode`
- `mvn -o compile -pl iotdb-core/confignode -DskipTests` (Checkstyle and Spotless passed; the local JVM ran out of native memory during `javac`.)
- Targeted `javac` compilation of `PullCommitProgressRPCHandler.java` against existing module artifacts passed.

## Checklist

- [x] Self-reviewed
- [x] No unrelated files changed