### PR TITLE
Tune Edge compaction and TsFile defaults

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/edge/it/IoTDBEdgeBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/edge/it/IoTDBEdgeBasicIT.java
@@ -195,6 +195,18 @@ public class IoTDBEdgeBasicIT {
   @Test
   public void testPackagedConfiguration() throws Exception {
     assertFalse(PACKAGED_SYSTEM_PROPERTIES.containsKey("model_inference_execution_thread_count"));
+    assertEdgeProperty("candidate_compaction_task_queue_size", "10");
+    assertEdgeProperty("compaction_max_aligned_series_num_in_one_batch", "2");
+    assertEdgeProperty("target_compaction_file_size", "10485760");
+    assertEdgeProperty("inner_compaction_total_file_size_threshold", "52428800");
+    assertEdgeProperty("inner_compaction_total_file_num_threshold", "10");
+    assertEdgeProperty("inner_compaction_candidate_file_num", "5");
+    assertEdgeProperty("max_cross_compaction_candidate_file_num", "10");
+    assertEdgeProperty("max_cross_compaction_candidate_file_size", "52428800");
+    assertEdgeProperty("target_chunk_point_num", "10000");
+    assertEdgeProperty("target_chunk_size", "262144");
+    assertEdgeProperty("max_number_of_points_in_page", "1000");
+    assertEdgeProperty("page_size_in_byte", "16384");
     assertTrue(Files.isRegularFile(edgeHome.resolve("sbin/windows/check-edge.ps1")));
 
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -215,6 +227,13 @@ public class IoTDBEdgeBasicIT {
       final String name = ((Element) references.item(i)).getAttribute("ref");
       assertTrue("Undefined Edge log appender: " + name, appenderNames.contains(name));
     }
+  }
+
+  private static void assertEdgeProperty(final String name, final String expectedValue) {
+    assertEquals(
+        "Unexpected packaged Edge value for " + name,
+        expectedValue,
+        PACKAGED_SYSTEM_PROPERTIES.getProperty(name));
   }
 
   private static String jdbcUrl() {

--- a/integration-test/src/test/java/org/apache/iotdb/edge/it/IoTDBEdgeBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/edge/it/IoTDBEdgeBasicIT.java
@@ -197,10 +197,10 @@ public class IoTDBEdgeBasicIT {
     assertFalse(PACKAGED_SYSTEM_PROPERTIES.containsKey("model_inference_execution_thread_count"));
     assertEdgeProperty("candidate_compaction_task_queue_size", "10");
     assertEdgeProperty("compaction_max_aligned_series_num_in_one_batch", "2");
-    assertEdgeProperty("target_compaction_file_size", "10485760");
+    assertEdgeProperty("target_compaction_file_size", "33554432");
     assertEdgeProperty("inner_compaction_total_file_size_threshold", "52428800");
     assertEdgeProperty("inner_compaction_total_file_num_threshold", "10");
-    assertEdgeProperty("inner_compaction_candidate_file_num", "5");
+    assertEdgeProperty("inner_compaction_candidate_file_num", "8");
     assertEdgeProperty("max_cross_compaction_candidate_file_num", "10");
     assertEdgeProperty("max_cross_compaction_candidate_file_size", "52428800");
     assertEdgeProperty("target_chunk_point_num", "10000");

--- a/iotdb-core/node-commons/src/assembly/resources/conf/edge/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/edge/iotdb-system.properties
@@ -115,10 +115,10 @@ config_node_ratis_log_appender_buffer_size_max=4194304
 # ---- compaction working set ----
 candidate_compaction_task_queue_size=10
 compaction_max_aligned_series_num_in_one_batch=2
-target_compaction_file_size=10485760
+target_compaction_file_size=33554432
 inner_compaction_total_file_size_threshold=52428800
 inner_compaction_total_file_num_threshold=10
-inner_compaction_candidate_file_num=5
+inner_compaction_candidate_file_num=8
 max_cross_compaction_candidate_file_num=10
 max_cross_compaction_candidate_file_size=52428800
 

--- a/iotdb-core/node-commons/src/assembly/resources/conf/edge/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/edge/iotdb-system.properties
@@ -103,11 +103,24 @@ max_allowed_concurrent_queries=100
 # ---- memory / file buffers ----
 wal_buffer_size_in_byte=1048576
 group_size_in_byte=4194304
-target_compaction_file_size=134217728
+target_chunk_point_num=10000
+target_chunk_size=262144
+page_size_in_byte=16384
+max_number_of_points_in_page=1000
 into_operation_buffer_size_in_byte=8388608
 batch_size=10000
 schema_region_ratis_log_appender_buffer_size_max=4194304
 config_node_ratis_log_appender_buffer_size_max=4194304
+
+# ---- compaction working set ----
+candidate_compaction_task_queue_size=10
+compaction_max_aligned_series_num_in_one_batch=2
+target_compaction_file_size=10485760
+inner_compaction_total_file_size_threshold=52428800
+inner_compaction_total_file_num_threshold=10
+inner_compaction_candidate_file_num=5
+max_cross_compaction_candidate_file_num=10
+max_cross_compaction_candidate_file_size=52428800
 
 # ---- background io politeness (share disks with other processes) ----
 compaction_write_throughput_mb_per_sec=8


### PR DESCRIPTION
## Summary

- tune Edge-only compaction queue, aligned-series batching, and inner/cross-space candidate limits
- use a 32 MiB target with eight first-level candidates, based on an Edge-specific 1-device x 100-measurement workload
- use smaller TsFile chunk and page targets for the constrained Edge profile
- assert every packaged Edge default in the dedicated integration test

## Rationale

This follows the parameter suggestions from the Edge distribution mailing-list discussion, with the file-size policy adjusted using an empirical Edge workload instead of applying every suggested value verbatim.

The Edge process uses a 224 MiB maximum heap. With the current memory ratios, one active aligned MemTable with 100 DOUBLE measurements flushed every 25,000 rows in the probe. Each flush contained 20,300,000 bytes of logical MemTable data.

With deterministic data calibrated to an observed 5.08x compression ratio, each natural flush produced an approximately 4.02 MB TsFile. A 32 MiB compaction target paired with eight candidate files therefore creates an approximately 32 MB stable first-level file.

The inner and cross-space input-size limits remain at 50 MiB. This intentionally prevents two approximately 32 MB files from being compacted again into one approximately 64 MB file for a single-device workload, avoiding an additional write-amplification level while still bounding every task. The aligned-series batch of 2 and the smaller chunk/page targets bound temporary memory during compaction and file writing. All overrides remain isolated to the Edge archive.

## Empirical validation

Workload: one aligned device, 100 DOUBLE measurements using GORILLA and LZ4, 400,000 rows and 40,000,000 values in total.

- observed compression ratio: 5.08x
- natural flush boundary: 25,000 rows and 2,500,000 values
- logical data per flush: 20,300,000 bytes
- natural TsFile size: approximately 4.02 MB
- each inner compaction selected 8 files, approximately 30 MiB total input
- estimated memory per compaction task: 3.64 MiB
- output sizes: 32,115,699 bytes and 32,115,029 bytes
- task times: 2.86 seconds and 2.84 seconds
- a later scheduler pass kept both approximately 32 MB files, confirming the 50 MiB cap prevented a 64 MB second-level merge
- post-compaction count remained 400,000 rows
- sampled combined Edge process RSS stayed below 425 MiB

## Build and integration validation

- mvn spotless:apply -P with-integration-tests -pl integration-test
- mvn clean package -DskipTests -pl distribution -am
- verified all six binary distribution ZIPs are still produced
- inspected the Edge ZIP and verified all proposed values are packaged
- mvn verify -DskipUTs -Dit.test=IoTDBEdgeBasicIT -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -P EdgeIT -P with-integration-tests
