### PR TITLE
Bump C++ client bundled Thrift from 0.23.0 to 0.24.0

### DIFF
--- a/iotdb-client/client-cpp/CMakeLists.txt
+++ b/iotdb-client/client-cpp/CMakeLists.txt
@@ -19,7 +19,7 @@
 # Apache IoTDB - C++ Session Client (top-level CMake build)
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 project(iotdb_session CXX C)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -97,7 +97,7 @@ else()
 endif()
 set(BOOST_VERSION "${_iotdb_default_boost_version}"
     CACHE STRING "Boost version used when downloading / unpacking (Thrift build only)")
-set(THRIFT_VERSION "0.23.0"
+set(THRIFT_VERSION "0.24.0"
     CACHE STRING "Apache Thrift version used when downloading / building")
 
 if(WIN32)

--- a/iotdb-client/client-cpp/README.md
+++ b/iotdb-client/client-cpp/README.md
@@ -71,7 +71,7 @@ separate Thrift or Boost headers/libraries for normal SDK use.
 ### 2. Link with CMake
 
 ```cmake
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 project(my_iotdb_app LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -300,7 +300,7 @@ so they require glibc 2.28 or newer on the deployment host.
 | ppc64le | `quay.io/pypa/manylinux_2_28_ppc64le` |
 | s390x | `quay.io/pypa/manylinux_2_28_s390x` |
 
-Thrift **0.23.0** is compiled from source during the CMake configure step (see
+Thrift **0.24.0** is compiled from source during the CMake configure step (see
 `cmake/FetchThrift.cmake`). Older releases that used pre-built
 `iotdb-tools-thrift` Maven artifacts and `-Diotdb-tools-thrift.version=...`
 for glibc/MSVC compatibility apply only to the **legacy** client-cpp build;
@@ -384,7 +384,7 @@ etc. directly.
 | `IOTDB_OFFLINE`       | `OFF`                            | Disallow any network access during configure.                                                            |
 | `IOTDB_DEPS_DIR`      | `<client-cpp>/third-party`       | Override the local tarball cache directory.                                                              |
 | `BOOST_VERSION`       | `1.60.0` (`1.84.0` on macOS)     | Boost version that CMake will look for / download.                                                       |
-| `THRIFT_VERSION`      | `0.23.0`                         | Apache Thrift version to build from source.                                                              |
+| `THRIFT_VERSION`      | `0.24.0`                         | Apache Thrift version to build from source.                                                              |
 | `BOOST_ROOT`          | (unset)                          | Existing Boost install to reuse, equivalent to `-Dboost.include.dir=...` from the legacy build.          |
 | `OPENSSL_ROOT_DIR`    | (unset)                          | Existing OpenSSL install when `WITH_SSL=ON`.                                                             |
 | `CMAKE_INSTALL_PREFIX`| `<build>/install`                | Install location.                                                                                        |
@@ -427,12 +427,12 @@ cmake --build build --config Release --target install
 
    | Platform   | Required files                                                                                                                                                       |
    |------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-   | `linux/`   | `thrift-0.23.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (and `openssl-3.5.0.tar.gz` only when `WITH_SSL=ON` and no system OpenSSL is present) |
-   | `mac/`     | `thrift-0.23.0.tar.gz`, `boost_1_84_0.tar.gz` (newer Boost for Xcode/Clang; Apple ships m4/flex/bison; `openssl-3.5.0.tar.gz` optional)                               |
-   | `windows/` | `thrift-0.23.0.tar.gz`, `boost_1_60_0.tar.gz` (Boost headers only - no `b2` build required for `iotdb_session`)                                                      |
+   | `linux/`   | `thrift-0.24.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (and `openssl-3.5.0.tar.gz` only when `WITH_SSL=ON` and no system OpenSSL is present) |
+   | `mac/`     | `thrift-0.24.0.tar.gz`, `boost_1_84_0.tar.gz` (newer Boost for Xcode/Clang; Apple ships m4/flex/bison; `openssl-3.5.0.tar.gz` optional)                               |
+   | `windows/` | `thrift-0.24.0.tar.gz`, `boost_1_60_0.tar.gz` (Boost headers only - no `b2` build required for `iotdb_session`)                                                      |
 
    Reference URLs (the configure step uses the same):
-   - Apache Thrift 0.23.0: <https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz>
+   - Apache Thrift 0.24.0: <https://archive.apache.org/dist/thrift/0.24.0/thrift-0.24.0.tar.gz>
    - Boost 1.60.0:        <https://archives.boost.io/release/1.60.0/source/boost_1_60_0.tar.gz>
    - GNU m4 1.4.19:       <https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz>
    - GNU flex 2.6.4:      <https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz>
@@ -461,7 +461,7 @@ CI environments can share a single cache by setting
 ### Linux
 
 - Tested with GCC 7+ and Clang 9+. Anything that can compile Apache Thrift
-  0.23.0 works.
+  0.24.0 works.
 - Build deps that must already exist on the host (only required when
   CMake auto-builds m4/flex/bison from tarball): `make`, `autoconf`,
   `gcc`, plus the standard C/C++ toolchain. `sudo` is **not** required;

--- a/iotdb-client/client-cpp/README_zh.md
+++ b/iotdb-client/client-cpp/README_zh.md
@@ -72,7 +72,7 @@ Thrift 或 Boost 的头文件/库。
 项目中的 `CMakeLists.txt` 可这样写：
 
 ```cmake
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 project(my_iotdb_app LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -243,7 +243,7 @@ Maven 构建会把 SDK 安装到 `target/install/`，并生成
 | `BOOST_INCLUDEDIR` | `boost.include.dir` |
 | `CMAKE_BUILD_TYPE` | `cmake.build.type`，例如 `-Dcmake.build.type=Debug` |
 
-SSL 默认开启（`WITH_SSL=ON`）。所捆绑的 Apache Thrift 0.23 同时支持 OpenSSL 1.x
+SSL 默认开启（`WITH_SSL=ON`）。所捆绑的 Apache Thrift 0.24 同时支持 OpenSSL 1.x
 与 3.x，因此直接使用系统的 OpenSSL（任意版本）。CMake 通过 `find_package(OpenSSL)`
 解析系统 OpenSSL，找不到时回退到从源码构建 OpenSSL 3.5.0；并会把所用的 OpenSSL
 动态库一并复制到产物 `lib/` 目录。Windows 可用 `choco install openssl` 安装。

--- a/iotdb-client/client-cpp/cmake/FetchBuildTools.cmake
+++ b/iotdb-client/client-cpp/cmake/FetchBuildTools.cmake
@@ -253,7 +253,7 @@ if(NOT FLEX_EXECUTABLE)
 endif()
 message(STATUS "[BuildTools] flex  = ${FLEX_EXECUTABLE}")
 
-# bison - Thrift 0.23's grammar build uses bison >= 3.7 features (e.g. the
+# bison - Thrift 0.24's grammar build uses bison >= 3.7 features (e.g. the
 # --file-prefix-map option), so reject an older system bison (manylinux_2_28
 # ships 3.0.4) and build ${BISON_VERSION} from source instead.
 set(_bison_min_version "3.7")

--- a/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
+++ b/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
@@ -18,7 +18,7 @@
 # =============================================================================
 # FetchOpenSSL.cmake  (only included when WITH_SSL=ON)
 #
-# Apache Thrift 0.23 (bundled by this client) builds against OpenSSL 1.x and 3.x,
+# Apache Thrift 0.24 (bundled by this client) builds against OpenSSL 1.x and 3.x,
 # so any system OpenSSL is used as-is, whatever its version.
 #
 # Resolution order:

--- a/iotdb-client/client-cpp/examples/CMakeLists.txt
+++ b/iotdb-client/client-cpp/examples/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
 CMAKE_POLICY(SET CMP0091 NEW)
 
 # Windows SDK zips are x86_64; Visual Studio generators (especially VS2017) default to Win32.

--- a/iotdb-client/client-cpp/examples/README.md
+++ b/iotdb-client/client-cpp/examples/README.md
@@ -53,7 +53,7 @@ publishes one zip per platform/toolchain:
 | macOS arm64 | `macos-aarch64` |
 | Windows (match your Visual Studio version) | `windows-x86_64-msvc14.1` ... `msvc14.4` |
 
-The current build compiles Thrift 0.23 from source at CMake configure time.
+The current build compiles Thrift 0.24 from source at CMake configure time.
 Legacy `-Diotdb-tools-thrift.version=...` flags applied to the **old**
 pre-built Thrift workflow only. Linux release packages are built in the
 `manylinux_2_28` container and require glibc 2.28 or newer. See

--- a/iotdb-client/client-cpp/examples/README_zh.md
+++ b/iotdb-client/client-cpp/examples/README_zh.md
@@ -52,7 +52,7 @@ CI 发版（[client-cpp-package.yml](../../.github/workflows/client-cpp-package.
 | macOS arm64 | `macos-aarch64` |
 | Windows + 与工程相同的 VS 版本 | `windows-x86_64-msvc14.1` ... `msvc14.4` |
 
-当前 CMake 构建在配置阶段从源码编译 Thrift 0.23，**不再**通过
+当前 CMake 构建在配置阶段从源码编译 Thrift 0.24，**不再**通过
 `-Diotdb-tools-thrift.version=0.14.1.1-gcc4-SNAPSHOT` 等旧参数控制 glibc；
 Linux 发版包在 `manylinux_2_28` 容器中构建，部署机需要 glibc 2.28 或更新版本。
 详见 [client-cpp README](../../iotdb-client/client-cpp/README.md)。

--- a/iotdb-client/client-cpp/src/assembly/package-metadata/third_party/DEPENDENCIES.md
+++ b/iotdb-client/client-cpp/src/assembly/package-metadata/third_party/DEPENDENCIES.md
@@ -31,7 +31,7 @@ the [`NOTICE`](NOTICE) file in this directory; non-Apache license texts are unde
 
 | Component | Version | How | License |
 | --- | --- | --- | --- |
-| Apache Thrift | 0.23.0 | statically linked | Apache License 2.0 |
+| Apache Thrift | 0.24.0 | statically linked | Apache License 2.0 |
 | Boost | 1.60.0 on Linux/Windows, 1.84.0 on macOS by default | statically linked (header-only) | Boost Software License 1.0 |
 | OpenSSL | 3.x: system OpenSSL 3.x when present, else 3.5.0 built from source (`WITH_SSL=ON`, default) | bundled shared libs in `lib/` | Apache License 2.0 |
 

--- a/iotdb-client/client-cpp/third-party/README.md
+++ b/iotdb-client/client-cpp/third-party/README.md
@@ -68,8 +68,8 @@ Alternatively copy files manually from the URLs listed in
 
 | Platform   | Typical files |
 |------------|---------------|
-| `linux/`   | `thrift-0.23.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (+ `openssl-3.5.0.tar.gz` only when `WITH_SSL=ON` and no system OpenSSL is present) |
-| `mac/`     | `thrift-0.23.0.tar.gz`, `boost_1_60_0.tar.gz` (Xcode CLT usually provides m4/flex/bison) |
-| `windows/` | `thrift-0.23.0.tar.gz`, `boost_1_60_0.tar.gz`, `win_flex_bison-2.5.25.zip` (or any `win_flex_bison*.zip`; skip if flex/bison already on `PATH`) |
+| `linux/`   | `thrift-0.24.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (+ `openssl-3.5.0.tar.gz` only when `WITH_SSL=ON` and no system OpenSSL is present) |
+| `mac/`     | `thrift-0.24.0.tar.gz`, `boost_1_60_0.tar.gz` (Xcode CLT usually provides m4/flex/bison) |
+| `windows/` | `thrift-0.24.0.tar.gz`, `boost_1_60_0.tar.gz`, `win_flex_bison-2.5.25.zip` (or any `win_flex_bison*.zip`; skip if flex/bison already on `PATH`) |
 
 Download URLs: see the *Offline build* table in [`README.md`](../README.md).


### PR DESCRIPTION
## Summary

- Upgrade `iotdb-client/client-cpp` bundled Apache Thrift from **0.23.0** to **0.24.0** to address C++-side CVEs
- Raise `cmake_minimum_required` from 3.15 to 3.16 (required by Thrift 0.24.0)
- Update docs, package metadata, and offline dependency cache filenames (`thrift-0.24.0.tar.gz`)
- Keep manylinux_2_28 (glibc 2.28) release baseline and other third-party versions unchanged

## Test plan

- [x] `mvn spotless:apply -P with-cpp -pl iotdb-client/client-cpp`
- [x] `mvn -P with-cpp -pl iotdb-client/client-cpp -am -DskipTests package` (Linux x86_64, `linux-x86_64-glibc2.28`)
- [x] Verified SDK Package https://github.com/hongzhi-gao/iotdb/actions/runs/33587722150