### PR TITLE
Pipe: Load TsFile classes from parent class loader (dev/1.3)

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoader.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoader.java
@@ -36,7 +36,13 @@ import java.util.stream.Stream;
 public class PipePluginClassLoader extends URLClassLoader {
 
   private static final String[] PARENT_FIRST_CLASS_PREFIXES = {
-    "java.", "javax.", "jdk.", "sun.", "org.slf4j.", "org.apache.iotdb.pipe.api."
+    "java.",
+    "javax.",
+    "jdk.",
+    "sun.",
+    "org.slf4j.",
+    "org.apache.iotdb.pipe.api.",
+    "org.apache.tsfile."
   };
 
   private final String libRoot;

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoaderTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoaderTest.java
@@ -46,6 +46,41 @@ import java.util.stream.Stream;
 public class PipePluginClassLoaderTest {
 
   @Test
+  public void testTsFileClassesShouldBeLoadedFromParent() throws Exception {
+    final Path tempDir = Files.createTempDirectory("pipe-plugin-tsfile-classloader-test");
+    try {
+      final Path childSources = Files.createDirectory(tempDir.resolve("child-sources"));
+      final Path childClasses = Files.createDirectory(tempDir.resolve("child-classes"));
+      final String tabletClassName = "org.apache.tsfile.write.record.Tablet";
+      final String childTabletSource =
+          "package org.apache.tsfile.write.record;"
+              + "public class Tablet {"
+              + "  public String source() {"
+              + "    return \"child\";"
+              + "  }"
+              + "}";
+      final Map<String, String> childSourceMap = new LinkedHashMap<>();
+      childSourceMap.put(tabletClassName, childTabletSource);
+      compile(childSources, childClasses, childSourceMap);
+
+      final Path childJar = tempDir.resolve("child.jar");
+      createJar(
+          childJar, childClasses, Arrays.asList("org/apache/tsfile/write/record/Tablet.class"));
+
+      final ClassLoader parentClassLoader = PipePluginClassLoaderTest.class.getClassLoader();
+      final Class<?> parentTabletClass = Class.forName(tabletClassName, true, parentClassLoader);
+      try (final PipePluginClassLoader pluginClassLoader =
+          new PipePluginClassLoader(childJar.toString(), parentClassLoader)) {
+        final Class<?> pluginTabletClass = Class.forName(tabletClassName, true, pluginClassLoader);
+        Assert.assertSame(parentTabletClass, pluginTabletClass);
+        Assert.assertNotSame(pluginClassLoader, pluginTabletClass.getClassLoader());
+      }
+    } finally {
+      deleteRecursively(tempDir);
+    }
+  }
+
+  @Test
   public void testPluginClassesShouldOverrideParentClasses() throws Exception {
     final Path tempDir = Files.createTempDirectory("pipe-plugin-classloader-test");
     try {


### PR DESCRIPTION
## Description

Backport of #18578 to `dev/1.3`.

### Problem

`PipePluginClassLoader` uses child-first loading for external plugin dependencies, while delegating shared API packages to the parent class loader. TsFile classes are also exposed by the Pipe API boundary, for example `TabletInsertionEvent#processTablet` passes an `org.apache.tsfile.write.record.Tablet` to plugin code.

If an external plugin bundles TsFile, the plugin class loader currently loads a second copy of `Tablet`. A core-created `Tablet` can then fail with a same-class-name `ClassCastException` because the two copies have different class loaders, preventing the sink from processing events.

### Fix

Add `org.apache.tsfile.` to the parent-first package prefixes. This keeps TsFile types shared across the Pipe API boundary while preserving child-first loading for ordinary plugin implementation classes and dependencies.

### Test

Add a regression test that creates a plugin JAR containing a duplicate fake `org.apache.tsfile.write.record.Tablet`, then verifies that the plugin class loader resolves the parent TsFile class. The existing test continues to verify child-first loading for normal plugin classes.

Tested with:

```shell
./mvnw -pl iotdb-core/node-commons -Dtest=PipePluginClassLoaderTest -DskipITs test
```

This PR has:

- [x] been self-reviewed.
- [x] added unit tests covering the new class-loading path.

##### Key changed/added classes

- `PipePluginClassLoader`
- `PipePluginClassLoaderTest`
