### PR TITLE
Make Edge query and load-event thread pools configurable

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/edge/it/IoTDBEdgeBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/edge/it/IoTDBEdgeBasicIT.java
@@ -58,6 +58,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -180,9 +184,87 @@ public class IoTDBEdgeBasicIT {
     }
   }
 
+  @Test
+  public void testConcurrentTableQueriesWithSmallThreadPools() throws Exception {
+    try (Connection connection = openTableConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DATABASE edge_it_concurrent");
+      statement.execute("USE edge_it_concurrent");
+      statement.execute("CREATE TABLE sensor(device STRING TAG, value INT32 FIELD)");
+      statement.execute("INSERT INTO sensor(time,device,value) VALUES (1,'d1',42), (2,'d1',84)");
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(4);
+    CountDownLatch ready = new CountDownLatch(4);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Future<Void>> queries = new ArrayList<>();
+    try {
+      for (int i = 0; i < 4; i++) {
+        queries.add(
+            executor.submit(
+                () -> {
+                  try (Connection connection = openTableConnection();
+                      Statement statement = connection.createStatement()) {
+                    statement.execute("USE edge_it_concurrent");
+                    ready.countDown();
+                    assertTrue(start.await(30, TimeUnit.SECONDS));
+                    for (int iteration = 0; iteration < 20; iteration++) {
+                      try (ResultSet result =
+                          statement.executeQuery("SELECT sum(value) FROM sensor")) {
+                        assertTrue(result.next());
+                        assertEquals(126.0, result.getDouble(1), 0.0);
+                        assertFalse(result.next());
+                      }
+                      try (ResultSet result =
+                          statement.executeQuery(
+                              "SELECT value FROM sensor WHERE device='d1' ORDER BY time")) {
+                        assertTrue(result.next());
+                        assertEquals(42, result.getInt(1));
+                        assertTrue(result.next());
+                        assertEquals(84, result.getInt(1));
+                        assertFalse(result.next());
+                      }
+                    }
+                  }
+                  return null;
+                }));
+      }
+      assertTrue(ready.await(30, TimeUnit.SECONDS));
+      start.countDown();
+      for (Future<Void> query : queries) {
+        query.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+
   private static Connection openTreeConnection() throws SQLException {
     return DriverManager.getConnection(
         jdbcUrl(), SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD);
+  }
+
+  @Test
+  public void testRatisMetadataConsensus() throws SQLException {
+    Map<String, String> variables = new LinkedHashMap<>();
+    try (Connection connection = openTableConnection();
+        Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery("SHOW VARIABLES")) {
+      while (result.next()) {
+        variables.put(result.getString(1), result.getString(2));
+      }
+    }
+    assertEquals(
+        "org.apache.iotdb.consensus.ratis.RatisConsensus",
+        variables.get("ConfigNodeConsensusProtocolClass"));
+    assertEquals(
+        "org.apache.iotdb.consensus.ratis.RatisConsensus",
+        variables.get("SchemaRegionConsensusProtocolClass"));
+    assertEquals(
+        "org.apache.iotdb.consensus.iot.IoTConsensus",
+        variables.get("DataRegionConsensusProtocolClass"));
   }
 
   private static Connection openTableConnection() throws SQLException {
@@ -195,6 +277,10 @@ public class IoTDBEdgeBasicIT {
   @Test
   public void testPackagedConfiguration() throws Exception {
     assertFalse(PACKAGED_SYSTEM_PROPERTIES.containsKey("model_inference_execution_thread_count"));
+    assertEdgeProperty("coordinator_read_executor_size", "2");
+    assertEdgeProperty("coordinator_scheduled_executor_size", "2");
+    assertEdgeProperty("fragment_instance_notification_thread_count", "2");
+    assertEdgeProperty("cn_load_statistics_publisher_thread_count", "1");
     assertEdgeProperty("candidate_compaction_task_queue_size", "10");
     assertEdgeProperty("compaction_max_aligned_series_num_in_one_batch", "2");
     assertEdgeProperty("target_compaction_file_size", "33554432");

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -202,6 +202,9 @@ public class ConfigNodeConfig {
   private int procedureCoreWorkerThreadsCount =
       Math.max(Runtime.getRuntime().availableProcessors() / 4, 16);
 
+  /** Thread pool size for publishing cluster load statistics changes. */
+  private int loadStatisticsPublisherThreadCount = 5;
+
   /** The heartbeat interval in milliseconds. */
   private volatile long heartbeatIntervalInMs = 1000;
 
@@ -736,6 +739,17 @@ public class ConfigNodeConfig {
 
   public void setProcedureCoreWorkerThreadsCount(int procedureCoreWorkerThreadsCount) {
     this.procedureCoreWorkerThreadsCount = procedureCoreWorkerThreadsCount;
+  }
+
+  public int getLoadStatisticsPublisherThreadCount() {
+    return loadStatisticsPublisherThreadCount;
+  }
+
+  public void setLoadStatisticsPublisherThreadCount(int loadStatisticsPublisherThreadCount) {
+    if (loadStatisticsPublisherThreadCount <= 0) {
+      throw new IllegalArgumentException(CommonMessages.SIZE_MUST_BE_POSITIVE);
+    }
+    this.loadStatisticsPublisherThreadCount = loadStatisticsPublisherThreadCount;
   }
 
   public long getHeartbeatIntervalInMs() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -402,6 +402,12 @@ public class ConfigNodeDescriptor {
                 "procedure_core_worker_thread_count",
                 String.valueOf(conf.getProcedureCoreWorkerThreadsCount()))));
 
+    conf.setLoadStatisticsPublisherThreadCount(
+        Integer.parseInt(
+            properties.getProperty(
+                "cn_load_statistics_publisher_thread_count",
+                String.valueOf(conf.getLoadStatisticsPublisherThreadCount()))));
+
     loadRatisConsensusConfig(properties);
     loadCQConfig(properties);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/EventService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/EventService.java
@@ -82,7 +82,10 @@ public class EventService {
         new AsyncEventBus(
             ThreadName.CONFIG_NODE_LOAD_PUBLISHER.getName(),
             IoTDBThreadPoolFactory.newFixedThreadPool(
-                5, ThreadName.CONFIG_NODE_LOAD_PUBLISHER.getName()));
+                ConfigNodeDescriptor.getInstance()
+                    .getConf()
+                    .getLoadStatisticsPublisherThreadCount(),
+                ThreadName.CONFIG_NODE_LOAD_PUBLISHER.getName()));
   }
 
   public void register(final IClusterStatusSubscriber listener) {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/conf/LoadStatisticsPublisherConfigTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/conf/LoadStatisticsPublisherConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.confignode.conf;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.ConfigurationFileUtils;
+import org.apache.iotdb.commons.conf.TrimProperties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class LoadStatisticsPublisherConfigTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testDefaultsAndPositiveSize() throws Exception {
+    ConfigNodeConfig config = new ConfigNodeConfig();
+    assertEquals(5, config.getLoadStatisticsPublisherThreadCount());
+    assertEquals(
+        "5",
+        ConfigurationFileUtils.getConfigurationDefaultValue(
+            "cn_load_statistics_publisher_thread_count"));
+    for (int invalid : new int[] {0, -1}) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> config.setLoadStatisticsPublisherThreadCount(invalid));
+    }
+    assertEquals(5, config.getLoadStatisticsPublisherThreadCount());
+  }
+
+  @Test
+  public void testStartupOverrideIsRestartOnly() throws Exception {
+    String originalConf = System.getProperty(ConfigNodeConstant.CONFIGNODE_CONF);
+    File confDir = temporaryFolder.newFolder();
+    Files.writeString(
+        confDir.toPath().resolve(CommonConfig.SYSTEM_CONFIG_NAME),
+        "cn_seed_config_node=127.0.0.1:10710\ncn_load_statistics_publisher_thread_count=2\n",
+        StandardCharsets.UTF_8);
+    System.setProperty(ConfigNodeConstant.CONFIGNODE_CONF, confDir.getAbsolutePath());
+    try {
+      Constructor<ConfigNodeDescriptor> constructor =
+          ConfigNodeDescriptor.class.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      ConfigNodeDescriptor descriptor = constructor.newInstance();
+      assertEquals(2, descriptor.getConf().getLoadStatisticsPublisherThreadCount());
+
+      TrimProperties properties = new TrimProperties();
+      properties.setProperty("cn_load_statistics_publisher_thread_count", "3");
+      descriptor.loadHotModifiedProps(properties);
+      assertEquals(2, descriptor.getConf().getLoadStatisticsPublisherThreadCount());
+    } finally {
+      if (originalConf == null) {
+        System.clearProperty(ConfigNodeConstant.CONFIGNODE_CONF);
+      } else {
+        System.setProperty(ConfigNodeConstant.CONFIGNODE_CONF, originalConf);
+      }
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.client.property.ClientPoolProperty.DefaultProper
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.enums.ReadConsistencyLevel;
+import org.apache.iotdb.commons.i18n.CommonMessages;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.consensus.ConsensusFactory;
@@ -1018,6 +1019,12 @@ public class IoTDBConfig {
 
   /** ThreadPool size for read operation in coordinator */
   private int coordinatorReadExecutorSize = 20;
+
+  /** Thread pool size for scheduling query state checks and termination. */
+  private int coordinatorScheduledExecutorSize = 10;
+
+  /** Thread pool size for fragment instance state change notifications. */
+  private int fragmentInstanceNotificationThreadCount = 4;
 
   /** Policy of DataNodeSchemaCache eviction */
   private String dataNodeSchemaCacheEvictionPolicy = "FIFO";
@@ -3576,7 +3583,33 @@ public class IoTDBConfig {
   }
 
   public void setCoordinatorReadExecutorSize(int coordinatorReadExecutorSize) {
+    if (coordinatorReadExecutorSize <= 0) {
+      throw new IllegalArgumentException(CommonMessages.SIZE_MUST_BE_POSITIVE);
+    }
     this.coordinatorReadExecutorSize = coordinatorReadExecutorSize;
+  }
+
+  public int getCoordinatorScheduledExecutorSize() {
+    return coordinatorScheduledExecutorSize;
+  }
+
+  public void setCoordinatorScheduledExecutorSize(int coordinatorScheduledExecutorSize) {
+    if (coordinatorScheduledExecutorSize <= 0) {
+      throw new IllegalArgumentException(CommonMessages.SIZE_MUST_BE_POSITIVE);
+    }
+    this.coordinatorScheduledExecutorSize = coordinatorScheduledExecutorSize;
+  }
+
+  public int getFragmentInstanceNotificationThreadCount() {
+    return fragmentInstanceNotificationThreadCount;
+  }
+
+  public void setFragmentInstanceNotificationThreadCount(
+      int fragmentInstanceNotificationThreadCount) {
+    if (fragmentInstanceNotificationThreadCount <= 0) {
+      throw new IllegalArgumentException(CommonMessages.SIZE_MUST_BE_POSITIVE);
+    }
+    this.fragmentInstanceNotificationThreadCount = fragmentInstanceNotificationThreadCount;
   }
 
   public TEndPoint getAddressAndPort() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1002,6 +1002,16 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "coordinator_read_executor_size",
                 Integer.toString(conf.getCoordinatorReadExecutorSize()))));
+    conf.setCoordinatorScheduledExecutorSize(
+        Integer.parseInt(
+            properties.getProperty(
+                "coordinator_scheduled_executor_size",
+                Integer.toString(conf.getCoordinatorScheduledExecutorSize()))));
+    conf.setFragmentInstanceNotificationThreadCount(
+        Integer.parseInt(
+            properties.getProperty(
+                "fragment_instance_notification_thread_count",
+                Integer.toString(conf.getFragmentInstanceNotificationThreadCount()))));
     conf.setDataNodeTableSchemaCacheSize(
         Long.parseLong(
             properties.getProperty(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceManager.java
@@ -111,7 +111,8 @@ public class FragmentInstanceManager {
             1, ThreadName.FRAGMENT_INSTANCE_MANAGEMENT.getName());
     this.instanceNotificationExecutor =
         IoTDBThreadPoolFactory.newFixedThreadPool(
-            4, ThreadName.FRAGMENT_INSTANCE_NOTIFICATION.getName());
+            IoTDBDescriptor.getInstance().getConfig().getFragmentInstanceNotificationThreadCount(),
+            ThreadName.FRAGMENT_INSTANCE_NOTIFICATION.getName());
 
     this.infoCacheTime = new Duration(5, TimeUnit.MINUTES);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -201,7 +201,6 @@ import static org.apache.tsfile.utils.RamUsageEstimator.sizeOfCharArray;
 public class Coordinator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Coordinator.class);
-  private static final int COORDINATOR_SCHEDULED_EXECUTOR_SIZE = 10;
   private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();
   private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
 
@@ -873,7 +872,7 @@ public class Coordinator {
 
   private ScheduledExecutorService getScheduledExecutor() {
     return IoTDBThreadPoolFactory.newScheduledThreadPool(
-        COORDINATOR_SCHEDULED_EXECUTOR_SIZE,
+        CONFIG.getCoordinatorScheduledExecutorSize(),
         ThreadName.MPP_COORDINATOR_SCHEDULED_EXECUTOR.getName());
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/QueryThreadPoolConfigTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/conf/QueryThreadPoolConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf;
+
+import org.apache.iotdb.commons.conf.ConfigurationFileUtils;
+import org.apache.iotdb.commons.conf.TrimProperties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class QueryThreadPoolConfigTest {
+
+  @Test
+  public void testDefaultsAndPositiveSizes() throws Exception {
+    IoTDBConfig config = new IoTDBConfig();
+    assertSizes(config, 20, 10, 4);
+    assertEquals(
+        "20",
+        ConfigurationFileUtils.getConfigurationDefaultValue("coordinator_read_executor_size"));
+    assertEquals(
+        "10",
+        ConfigurationFileUtils.getConfigurationDefaultValue("coordinator_scheduled_executor_size"));
+    assertEquals(
+        "4",
+        ConfigurationFileUtils.getConfigurationDefaultValue(
+            "fragment_instance_notification_thread_count"));
+
+    for (int invalid : new int[] {0, -1}) {
+      assertThrows(
+          IllegalArgumentException.class, () -> config.setCoordinatorReadExecutorSize(invalid));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> config.setCoordinatorScheduledExecutorSize(invalid));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> config.setFragmentInstanceNotificationThreadCount(invalid));
+    }
+    assertSizes(config, 20, 10, 4);
+  }
+
+  @Test
+  public void testStartupOverridesAreRestartOnly() throws Exception {
+    IoTDBDescriptor descriptor = new IoTDBDescriptor();
+    TrimProperties properties = new TrimProperties();
+    properties.setProperty("coordinator_read_executor_size", "3");
+    properties.setProperty("coordinator_scheduled_executor_size", "2");
+    properties.setProperty("fragment_instance_notification_thread_count", "1");
+    descriptor.loadProperties(properties);
+    assertSizes(descriptor.getConfig(), 3, 2, 1);
+
+    properties.setProperty("coordinator_read_executor_size", "6");
+    properties.setProperty("coordinator_scheduled_executor_size", "5");
+    properties.setProperty("fragment_instance_notification_thread_count", "4");
+    descriptor.loadHotModifiedProps(properties);
+    assertSizes(descriptor.getConfig(), 3, 2, 1);
+  }
+
+  private static void assertSizes(IoTDBConfig config, int read, int scheduled, int notification) {
+    assertEquals(read, config.getCoordinatorReadExecutorSize());
+    assertEquals(scheduled, config.getCoordinatorScheduledExecutorSize());
+    assertEquals(notification, config.getFragmentInstanceNotificationThreadCount());
+  }
+}

--- a/iotdb-core/node-commons/src/assembly/resources/conf/edge/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/edge/iotdb-system.properties
@@ -79,6 +79,10 @@ dn_metric_prometheus_reporter_port=9092
 # sharing the machine with other processes. Validated on x86 and Raspberry Pi 4B.
 
 # ---- thread pools (small fixed sizes instead of CPU-core-based defaults) ----
+coordinator_read_executor_size=2
+coordinator_scheduled_executor_size=2
+fragment_instance_notification_thread_count=2
+cn_load_statistics_publisher_thread_count=1
 query_thread_count=2
 degree_of_query_parallelism=1
 mpp_data_exchange_core_pool_size=2

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -759,6 +759,11 @@ time_partition_interval=604800000
 # Datatype: long
 heartbeat_interval_in_ms=1000
 
+# Number of ConfigNode workers publishing cluster load statistics changes. Must be positive.
+# effectiveMode: restart
+# Datatype: int
+cn_load_statistics_publisher_thread_count=5
+
 # Default failure detector, enum from {fixed, phi_accrual}
 # effectiveMode: restart
 # Datatype: string
@@ -1223,6 +1228,21 @@ max_allowed_concurrent_queries=1000
 # effectiveMode: restart
 # Datatype: int
 query_thread_count=0
+
+# Number of coordinator workers executing read queries. Must be positive.
+# effectiveMode: restart
+# Datatype: int
+coordinator_read_executor_size=20
+
+# Number of coordinator workers scheduling query state checks and termination. Must be positive.
+# effectiveMode: restart
+# Datatype: int
+coordinator_scheduled_executor_size=10
+
+# Number of workers notifying fragment instance state changes. Must be positive.
+# effectiveMode: restart
+# Datatype: int
+fragment_instance_notification_thread_count=4
 
 # How many pipeline drivers will be created for one fragment instance. When <= 0, use CPU core number / 2.
 # effectiveMode: restart


### PR DESCRIPTION
## Description

Normal table queries in the Edge process eventually start 20 coordinator workers, 10 coordinator scheduling workers, 4 fragment-notification workers and 5 ConfigNode load-event workers. The latter three pool sizes were hard-coded, and Edge did not override the existing coordinator read-pool setting.

Make these pool sizes configurable at startup and use smaller Edge defaults:

| Configuration | General default | Edge default |
| --- | ---: | ---: |
| `coordinator_read_executor_size` (existing) | 20 | 2 |
| `coordinator_scheduled_executor_size` | 10 | 2 |
| `fragment_instance_notification_thread_count` | 4 | 2 |
| `cn_load_statistics_publisher_thread_count` | 5 | 1 |

Values must be positive. Changes require a restart; the existing general defaults are preserved. The normal configuration template documents all four settings. ConfigNode and SchemaRegion continue to use Ratis; DataRegion continues to use IoTConsensus. JVM memory budgets and flush/compaction pools are unchanged.

## Validation

- Clean distribution build with `QueryThreadPoolConfigTest` and `LoadStatisticsPublisherConfigTest`: four tests passed, covering defaults, positive-size validation, startup loading and restart-only behavior.
- `IoTDBEdgeBasicIT`: package settings, tree/table reads and writes, 160 queries over four concurrent table connections, and runtime consensus-protocol assertions.
- Full-reactor English and Chinese test compilation.
- Before/after runs with the same JVM settings on Linux aarch64, a two-CPU quota and 4 GiB available memory: 100 devices × 100 DOUBLE fields, 1 Hz writes, two writers and four readers for 180 seconds. Each run wrote and verified 1,810,000 values with no failed requests or missed write rounds. `SHOW VARIABLES` confirmed Ratis for ConfigNode/SchemaRegion in both runs.
- Mid-load `jstack` thread entries changed from 147 to 115. The four pools changed from 20/10/4/5 to 2/2/2/1. NMT thread committed memory changed from 16,881 KiB to 13,249 KiB. Observed RSS peaks were about 341 and 338 MiB; this change reduces thread overhead and does not establish a total RSS cap.

## Self-review

- [x] Reviewed concurrent query execution and event delivery.
- [x] Documented configuration defaults and restart requirements.
- [x] Added configuration tests and concurrent Edge integration coverage.
- [x] Tested real read/write workloads with Ratis metadata consensus.
