### PR TITLE
[Backport] Pipe: optimize floating memory calculation (#16039)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
@@ -80,6 +80,7 @@ public class PipeInsertNodeTabletInsertionEvent extends EnrichedEvent
   private InsertNode insertNode;
 
   private ProgressIndex progressIndex;
+  private long bytes = Long.MIN_VALUE;
 
   private long extractTime = 0;
 
@@ -433,15 +434,18 @@ public class PipeInsertNodeTabletInsertionEvent extends EnrichedEvent
   }
 
   // Notes:
-  // 1. We only consider insertion event's memory for degrade and restart, because degrade/restart
-  // may not be of use for releasing other events' memory.
-  // 2. We do not consider eventParsers because they may not exist and if it is invoked, the event
+  // 1. We only consider insertion event's memory for degrading, because degrading may not be of use
+  // for releasing other events' memory.
+  // 2. We do not consider dataContainers because they may not exist and if it is invoked, the event
   // will soon be released.
   @Override
   public long ramBytesUsed() {
-    return INSTANCE_SIZE
-        + (Objects.nonNull(insertNode) ? InsertNodeMemoryEstimator.sizeOf(insertNode) : 0)
-        + (Objects.nonNull(progressIndex) ? progressIndex.ramBytesUsed() : 0);
+    return bytes > 0
+        ? bytes
+        : (bytes =
+            INSTANCE_SIZE
+                + (Objects.nonNull(insertNode) ? InsertNodeMemoryEstimator.sizeOf(insertNode) : 0)
+                + (Objects.nonNull(progressIndex) ? progressIndex.ramBytesUsed() : 0));
   }
 
   /////////////////////////// ReferenceTrackableEvent ///////////////////////////


### PR DESCRIPTION
Backport of apache/iotdb#16039 to dev/1.3.

The 1.3 branch uses an older EnrichedEvent API, so this backport carries the compatible floating-memory calculation optimization in PipeInsertNodeTabletInsertionEvent. The table-model and privilege-check portions of the source change do not apply to this branch.

Source PR: #16039

Validation:
- mvn spotless:apply -pl iotdb-core/datanode
- mvn compile -pl iotdb-core/datanode -DskipTests (fails on existing generated/cross-module compilation errors unrelated to this patch)