### PR TITLE
Bump ratis to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>ratis-snapshot</id>
+            <url>https://repository.apache.org/content/repositories/orgapacheratis-1184</url>
+        </repository>
     </repositories>
     <parent>
         <groupId>org.apache</groupId>
@@ -120,7 +124,7 @@
         <pax-jdbc-common.version>1.5.6</pax-jdbc-common.version>
         <powermock.version>2.0.9</powermock.version>
         <ratis-thirdparty-misc.version>1.1.0</ratis-thirdparty-misc.version>
-        <ratis.version>3.3.0</ratis.version>
+        <ratis.version>3.3.1</ratis.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <reactor-netty.version>1.2.18</reactor-netty.version>
         <reactor.version>3.7.19</reactor.version>


### PR DESCRIPTION
## Description

Bump Ratis from 3.3.0 to 3.3.1. Add the [Ratis 3.3.1 staging repository](https://repository.apache.org/content/repositories/orgapacheratis-1184/) to resolve the release candidate artifacts. Keep `ratis-thirdparty-misc` at 1.1.0, matching the Ratis 3.3.1 POM.

## Validation

- Passed `mvn -B -ntp -N validate spotless:check` and `git diff --check`.
- Confirmed availability of all seven Ratis 3.3.1 JARs declared in dependency management in the staging repository.
- Local consensus dependency resolution was stopped after repeated TLS handshake failures from the configured Maven snapshot mirror. Runtime compatibility has not been verified locally.

- [x] Self-reviewed.
