### PR TITLE
[Backport dev/1.3] [Pipe] Fix tablet type conversion for failed columns

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertTabletStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertTabletStatement.java
@@ -90,6 +90,9 @@ public class PipeConvertedInsertTabletStatement extends InsertTabletStatement {
 
   @Override
   protected boolean checkAndCastDataType(int columnIndex, TSDataType dataType) {
+    if (!isValidColumnForTypeConversion(columnIndex, dataType)) {
+      return false;
+    }
     if (LOGGER.isInfoEnabled()) {
       PipeLogger.log(
           LOGGER::info,
@@ -101,6 +104,28 @@ public class PipeConvertedInsertTabletStatement extends InsertTabletStatement {
         ArrayConverter.convert(dataTypes[columnIndex], dataType, columns[columnIndex]);
     dataTypes[columnIndex] = dataType;
     return true;
+  }
+
+  /**
+   * Returns whether a tablet column has all state required for type conversion.
+   *
+   * <p>Partial insert processing can leave a measurement slot without a data type or value column
+   * (and deserialized statements can contain arrays of different lengths). In that case the column
+   * must be treated as failed instead of being indexed by the conversion path.
+   */
+  protected boolean isValidColumnForTypeConversion(
+      final int columnIndex, final TSDataType dataType) {
+    return dataType != null
+        && dataTypes != null
+        && columns != null
+        && measurements != null
+        && columnIndex >= 0
+        && columnIndex < measurements.length
+        && columnIndex < dataTypes.length
+        && columnIndex < columns.length
+        && measurements[columnIndex] != null
+        && dataTypes[columnIndex] != null
+        && columns[columnIndex] != null;
   }
 
   protected boolean originalCheckAndCastDataType(int columnIndex, TSDataType dataType) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/converter/LoadConvertedInsertTabletStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/converter/LoadConvertedInsertTabletStatement.java
@@ -47,6 +47,10 @@ public class LoadConvertedInsertTabletStatement extends PipeConvertedInsertTable
       return originalCheckAndCastDataType(columnIndex, dataType);
     }
 
+    if (!isValidColumnForTypeConversion(columnIndex, dataType)) {
+      return false;
+    }
+
     LOGGER.info(
         "Load: Inserting tablet to {}.{}. Casting type from {} to {}.",
         devicePath,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertTabletStatementTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertTabletStatementTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.receiver.transform.statement;
+
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.exception.metadata.DataTypeMismatchException;
+import org.apache.iotdb.db.queryengine.common.schematree.MeasurementSchemaInfo;
+import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertTabletStatement;
+import org.apache.iotdb.db.storageengine.load.converter.LoadConvertedInsertTabletStatement;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.write.record.Tablet;
+import org.apache.tsfile.write.schema.MeasurementSchema;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PipeConvertedInsertTabletStatementTest {
+
+  private boolean enablePartialInsert;
+
+  @Before
+  public void setUp() {
+    enablePartialInsert = IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert();
+    IoTDBDescriptor.getInstance().getConfig().setEnablePartialInsert(true);
+  }
+
+  @After
+  public void tearDown() {
+    IoTDBDescriptor.getInstance().getConfig().setEnablePartialInsert(enablePartialInsert);
+  }
+
+  @Test
+  public void testTypeConversionSkipsMissingColumnWithoutException() throws Exception {
+    final InsertTabletStatement source = createPartiallyFailedStatementWithMissingColumn();
+    final PipeConvertedInsertTabletStatement converted =
+        new PipeConvertedInsertTabletStatement(source);
+
+    validateMeasurementSchema(converted, 0);
+    validateMeasurementSchema(converted, 1);
+
+    final Tablet tablet = converted.convertToTablet();
+    Assert.assertEquals(1, tablet.getSchemas().size());
+    Assert.assertEquals("s1", tablet.getSchemas().get(0).getMeasurementId());
+    Assert.assertEquals(TSDataType.DOUBLE, tablet.getSchemas().get(0).getType());
+    Assert.assertArrayEquals(new double[] {1.0, 2.0}, (double[]) tablet.values[0], 0.0);
+    Assert.assertNull(converted.getMeasurements()[1]);
+    Assert.assertNull(converted.getDataTypes()[1]);
+  }
+
+  @Test
+  public void testTypeConversionSkipsNullMeasurementWithoutException() throws Exception {
+    final InsertTabletStatement source = new InsertTabletStatement();
+    source.setDevicePath(new PartialPath("root.sg.d1"));
+    source.setMeasurements(new String[] {"s1", "s2"});
+    source.setDataTypes(new TSDataType[] {TSDataType.INT32, null});
+    source.setMeasurementSchemas(
+        new MeasurementSchema[] {
+          new MeasurementSchema("s1", TSDataType.DOUBLE),
+          new MeasurementSchema("s2", TSDataType.DOUBLE)
+        });
+    source.setTimes(new long[] {1L, 2L});
+    source.setColumns(new Object[] {new int[] {1, 2}, null});
+    source.setRowCount(2);
+    source.markFailedMeasurement(
+        1, new DataTypeMismatchException("root.sg.d1", "s2", null, TSDataType.DOUBLE, 1L, null));
+
+    Assert.assertNull(source.getMeasurements()[1]);
+
+    final PipeConvertedInsertTabletStatement converted =
+        new PipeConvertedInsertTabletStatement(source);
+    validateMeasurementSchema(converted, 0);
+    validateMeasurementSchema(converted, 1);
+
+    final Tablet tablet = converted.convertToTablet();
+
+    Assert.assertEquals(1, tablet.getSchemas().size());
+    Assert.assertEquals("s1", tablet.getSchemas().get(0).getMeasurementId());
+    Assert.assertEquals(TSDataType.DOUBLE, tablet.getSchemas().get(0).getType());
+    Assert.assertArrayEquals(new double[] {1.0, 2.0}, (double[]) tablet.values[0], 0.0);
+    Assert.assertNull(converted.getMeasurements()[1]);
+    Assert.assertNull(converted.getDataTypes()[1]);
+  }
+
+  @Test
+  public void testLoadTypeConversionSkipsMissingColumnWithoutException() throws Exception {
+    final LoadConvertedInsertTabletStatement converted =
+        new LoadConvertedInsertTabletStatement(
+            createPartiallyFailedStatementWithMissingColumn(), true);
+
+    validateMeasurementSchema(converted, 0);
+    validateMeasurementSchema(converted, 1);
+
+    final Tablet tablet = converted.convertToTablet();
+    Assert.assertEquals(1, tablet.getSchemas().size());
+    Assert.assertEquals(TSDataType.DOUBLE, tablet.getSchemas().get(0).getType());
+    Assert.assertArrayEquals(new double[] {1.0, 2.0}, (double[]) tablet.values[0], 0.0);
+  }
+
+  private static void validateMeasurementSchema(
+      final InsertTabletStatement statement, final int index) {
+    final MeasurementSchema schema = statement.getMeasurementSchemas()[index];
+    statement.validateMeasurementSchema(
+        index, new MeasurementSchemaInfo(schema.getMeasurementId(), schema, null, null, null));
+  }
+
+  private static InsertTabletStatement createPartiallyFailedStatementWithMissingColumn()
+      throws Exception {
+    final InsertTabletStatement source = new InsertTabletStatement();
+    source.setDevicePath(new PartialPath("root.sg.d1"));
+    source.setMeasurements(new String[] {"s1", "s2"});
+    source.setDataTypes(new TSDataType[] {TSDataType.INT32, TSDataType.INT64});
+    source.setMeasurementSchemas(
+        new MeasurementSchema[] {
+          new MeasurementSchema("s1", TSDataType.DOUBLE),
+          new MeasurementSchema("s2", TSDataType.DOUBLE)
+        });
+    source.setTimes(new long[] {1L, 2L});
+    source.setColumns(new Object[] {new int[] {1, 2}});
+    source.setRowCount(2);
+    source.markFailedMeasurement(
+        1,
+        new DataTypeMismatchException(
+            "root.sg.d1", "s2", TSDataType.INT64, TSDataType.DOUBLE, 1L, null));
+    return source;
+  }
+}


### PR DESCRIPTION
## Description

Backports #18595 (`31e7534811217440172d3b2edd27170ef8328c19`) to `dev/1.3`.

Pipe and Load conversion retries can restore failed measurements whose source type or value column is missing. Validate tablet column state before conversion so those measurements remain failed while valid columns still convert successfully.

The production changes apply unchanged. The regression tests use the 1.3 public `validateMeasurementSchema` entry point and TsFile API, and construct partial-insert failures through `markFailedMeasurement`.

## Validation

- `mvn spotless:apply -pl iotdb-core/datanode`: passed.
- `mvn test -pl iotdb-core/datanode -am -Dtest=PipeConvertedInsertTabletStatementTest -Dsurefire.failIfNoSpecifiedTests=false`: passed, all 26 reactor modules successful and all 3 regression tests passing.
- Ran the same tests against the pre-backport converter classes: all 3 fail, reproducing out-of-bounds access in Pipe/Load and an incorrectly retained null-typed measurement.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for the non-trivial validation method.
- [x] added unit tests covering Pipe and Load conversion of failed columns.

<hr>

##### Key changed/added classes

- `PipeConvertedInsertTabletStatement`
- `LoadConvertedInsertTabletStatement`
- `PipeConvertedInsertTabletStatementTest`
