### PR TITLE
Add MOMENT license and copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -369,4 +369,26 @@ The MOMENT is open source software licensed under the MIT License
 Project page: https://github.com/moment-timeseries-foundation-model/moment
 License: https://github.com/moment-timeseries-foundation-model/moment/blob/main/LICENSE
 
+MIT License
+
+Copyright (c) 2024 Auton Lab, Carnegie Mellon University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The source release currently identifies adapted MOMENT code but omits the upstream copyright notice and MIT license text. Add the complete MOMENT MIT license, including Copyright (c) 2024 Auton Lab, Carnegie Mellon University, to the root LICENSE so Apache source-release archives carry the required attribution.\n\nVerification:\n- Confirmed the upstream LICENSE text matches the current MOMENT main branch.\n- Confirmed the source-release candidate includes the root LICENSE and MOMENT MIT text.\n- git diff --check