### PR TITLE
Build: Replace Thrift and Drill FMPP Maven plugins

### DIFF
--- a/iotdb-core/calc-commons/pom.xml
+++ b/iotdb-core/calc-commons/pom.xml
@@ -182,25 +182,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- generate sources from fmpp -->
-                <groupId>org.apache.drill.tools</groupId>
-                <artifactId>drill-fmpp-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-fmpp</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <config>${project.build.directory}/codegen/config.fmpp</config>
-                            <output>${project.build.directory}/generated-sources/freemarker</output>
-                            <templates>${project.build.directory}/codegen/templates</templates>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
             </plugin>

--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -420,25 +420,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- generate sources from fmpp -->
-                <groupId>org.apache.drill.tools</groupId>
-                <artifactId>drill-fmpp-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-fmpp</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <config>${project.build.directory}/codegen/config.fmpp</config>
-                            <output>${project.build.directory}/generated-sources/freemarker</output>
-                            <templates>${project.build.directory}/codegen/templates</templates>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
@@ -450,7 +431,6 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <sources>
-                                <source>${project.build.directory}/generated-sources/freemarker</source>
                                 <source>${project.basedir}/src/main/i18n/${i18n.locale}</source>
                             </sources>
                         </configuration>

--- a/iotdb-protocol/thrift-ainode/pom.xml
+++ b/iotdb-protocol/thrift-ainode/pom.xml
@@ -29,6 +29,9 @@
     <artifactId>iotdb-thrift-ainode</artifactId>
     <name>IoTDB: Protocol: Thrift AI Node</name>
     <description>RPC (Thrift) framework among AINodes.</description>
+    <properties>
+        <thrift.source>ainode.thrift</thrift.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -44,26 +47,4 @@
             <version>2.0.11-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/thrift</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/iotdb-protocol/thrift-commons/pom.xml
+++ b/iotdb-protocol/thrift-commons/pom.xml
@@ -29,32 +29,14 @@
     <artifactId>iotdb-thrift-commons</artifactId>
     <name>IoTDB: Protocol: Thrift Commons</name>
     <description>RPC (Thrift) common framework.</description>
+    <properties>
+        <thrift.source>common.thrift</thrift.source>
+        <thrift.skip.client>false</thrift.skip.client>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/thrift</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/iotdb-protocol/thrift-confignode/pom.xml
+++ b/iotdb-protocol/thrift-confignode/pom.xml
@@ -29,6 +29,9 @@
     <artifactId>iotdb-thrift-confignode</artifactId>
     <name>IoTDB: Protocol: Thrift Config Node</name>
     <description>RPC (Thrift) framework among ConfigNodes.</description>
+    <properties>
+        <thrift.source>confignode.thrift</thrift.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -44,26 +47,4 @@
             <version>2.0.11-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/thrift</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/iotdb-protocol/thrift-consensus/pom.xml
+++ b/iotdb-protocol/thrift-consensus/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>iotdb-thrift-consensus</artifactId>
     <name>IoTDB: Protocol: Thrift Consensus</name>
     <description>RPC modules for consensus</description>
+    <properties>
+        <thrift.source>iotconsensus.thrift</thrift.source>
+        <thrift.skip.python>true</thrift.skip.python>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
@@ -48,18 +52,20 @@
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
+                <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
+                        <id>generate-iotconsensusv2-java</id>
                         <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
                         <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/thrift</source>
-                            </sources>
+                            <arguments combine.children="append">
+                                <argument>--gen</argument>
+                                <argument>java:generated_annotations=suppress</argument>
+                                <argument>${project.basedir}/src/main/thrift/iotconsensusv2.thrift</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/iotdb-protocol/thrift-datanode/pom.xml
+++ b/iotdb-protocol/thrift-datanode/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>iotdb-thrift</artifactId>
     <name>IoTDB: Protocol: Thrift Data Node</name>
     <description>RPC (Thrift) framework for client and DataNodes.</description>
+    <properties>
+        <thrift.source>client.thrift</thrift.source>
+        <thrift.skip.client>false</thrift.skip.client>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
@@ -84,18 +88,35 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
+                <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
+                        <id>generate-datanode-java</id>
                         <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
                         <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/thrift</source>
-                            </sources>
+                            <arguments combine.children="append">
+                                <argument>--gen</argument>
+                                <argument>java:generated_annotations=suppress</argument>
+                                <argument>${project.basedir}/src/main/thrift/datanode.thrift</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-datanode-python</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/generated-sources-python</workingDirectory>
+                            <arguments combine.children="append">
+                                <argument>--gen</argument>
+                                <argument>py</argument>
+                                <argument>${project.basedir}/src/main/thrift/datanode.thrift</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1846,11 +1846,11 @@
                         <groupId>org.codehaus.gmaven</groupId>
                         <artifactId>groovy-maven-plugin</artifactId>
                         <version>2.1.1</version>
-                        <!-- Only run this in the root module of the project -->
-                        <inherited>false</inherited>
                         <executions>
                             <execution>
                                 <id>compare-with-reference-list</id>
+                                <!-- Keep this check root-only without disabling inherited FMPP generation. -->
+                                <inherited>false</inherited>
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>execute</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -923,11 +923,6 @@
                     <version>3.6.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>3.2.0</version>
-                </plugin>
-                <plugin>
                     <groupId>com.bazaarvoice.maven.plugins</groupId>
                     <artifactId>process-exec-maven-plugin</artifactId>
                     <version>0.9</version>
@@ -1543,6 +1538,9 @@
             </activation>
             <properties>
                 <thrift.exec.absolute.path>${project.build.directory}/thrift/bin/${thrift.executable}</thrift.exec.absolute.path>
+                <thrift.skip.python>false</thrift.skip.python>
+                <!-- Go and C# are generated only from common.thrift and client.thrift. -->
+                <thrift.skip.client>true</thrift.skip.client>
             </properties>
             <build>
                 <plugins>
@@ -1573,44 +1571,81 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <executable>${thrift.exec.absolute.path}</executable>
+                            <!-- Exec creates the working directory before invoking Thrift. -->
+                            <workingDirectory>${project.build.directory}/generated-sources/thrift</workingDirectory>
+                            <arguments>
+                                <!-- Resolve shared IDL from source, including in clean reactor builds. -->
+                                <argument>-I</argument>
+                                <argument>${project.basedir}/../thrift-commons/src/main/thrift</argument>
+                                <argument>-out</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
                         <executions>
                             <execution>
-                                <id>generate-thrift-sources</id>
+                                <id>generate-thrift-sources-java</id>
                                 <phase>generate-sources</phase>
                                 <goals>
-                                    <goal>run</goal>
+                                    <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <target>
-                                        <!-- Apply runs once per matching IDL without requiring a platform-specific shell. -->
-                                        <macrodef name="generate-thrift">
-                                            <attribute name="generator"/>
-                                            <attribute name="includes" default="**/*.thrift"/>
-                                            <attribute name="output"/>
-                                            <sequential>
-                                                <mkdir dir="@{output}"/>
-                                                <apply executable="${thrift.exec.absolute.path}" failonerror="true" skipemptyfilesets="true">
-                                                    <arg value="--gen"/>
-                                                    <arg value="@{generator}"/>
-                                                    <arg value="-I"/>
-                                                    <arg file="${project.basedir}/src/main/thrift"/>
-                                                    <arg value="-I"/>
-                                                    <!-- Read shared IDL from source so clean reactor builds do not need packaged dependency JARs. -->
-                                                    <arg file="${project.basedir}/../thrift-commons/src/main/thrift"/>
-                                                    <arg value="-out"/>
-                                                    <arg file="@{output}"/>
-                                                    <fileset dir="${project.basedir}/src/main/thrift" includes="@{includes}"/>
-                                                </apply>
-                                            </sequential>
-                                        </macrodef>
-                                        <generate-thrift generator="java:generated_annotations=suppress" output="${project.build.directory}/generated-sources/thrift"/>
-                                        <generate-thrift generator="py" includes="**/common.thrift,**/client.thrift,**/datanode.thrift,**/confignode.thrift,**/ainode.thrift" output="${project.build.directory}/generated-sources-python"/>
-                                        <generate-thrift generator="go:package_prefix=github.com/apache/iotdb-client-go/v2/" includes="**/common.thrift,**/client.thrift" output="${project.build.directory}/generated-sources-go"/>
-                                        <!-- Keep the shared output directory used when copying the C# client sources. -->
-                                        <generate-thrift generator="netstd:no_deepcopy" includes="**/common.thrift,**/client.thrift" output="${project.basedir}/../target/generated-sources-csharp"/>
-                                    </target>
+                                    <arguments combine.children="append">
+                                        <argument>--gen</argument>
+                                        <argument>java:generated_annotations=suppress</argument>
+                                        <argument>${project.basedir}/src/main/thrift/${thrift.source}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>generate-thrift-sources-python</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${thrift.skip.python}</skip>
+                                    <workingDirectory>${project.build.directory}/generated-sources-python</workingDirectory>
+                                    <arguments combine.children="append">
+                                        <argument>--gen</argument>
+                                        <argument>py</argument>
+                                        <argument>${project.basedir}/src/main/thrift/${thrift.source}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>generate-thrift-sources-go</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${thrift.skip.client}</skip>
+                                    <workingDirectory>${project.build.directory}/generated-sources-go</workingDirectory>
+                                    <arguments combine.children="append">
+                                        <argument>--gen</argument>
+                                        <argument>go:package_prefix=github.com/apache/iotdb-client-go/v2/</argument>
+                                        <argument>${project.basedir}/src/main/thrift/${thrift.source}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>generate-thrift-sources-csharp</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${thrift.skip.client}</skip>
+                                    <workingDirectory>${project.parent.build.directory}/generated-sources-csharp</workingDirectory>
+                                    <arguments combine.children="append">
+                                        <argument>--gen</argument>
+                                        <argument>netstd:no_deepcopy</argument>
+                                        <argument>${project.basedir}/src/main/thrift/${thrift.source}</argument>
+                                    </arguments>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1619,6 +1654,18 @@
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
                         <executions>
+                            <execution>
+                                <id>add-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${project.build.directory}/generated-sources/thrift</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>add-thrift-resources</id>
                                 <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,15 @@
         <commons-pool2.version>2.11.1</commons-pool2.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <ctest.skip.tests>false</ctest.skip.tests>
-        <drill.freemarker.maven.plugin.version>1.21.1</drill.freemarker.maven.plugin.version>
         <dropwizard.metrics.version>4.2.19</dropwizard.metrics.version>
         <eclipse-collections.version>11.1.0</eclipse-collections.version>
         <!-- disable enforcer by default-->
         <enforcer.skip>true</enforcer.skip>
         <felix.version>5.1.9</felix.version>
         <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
+        <fmpp.version>0.9.14</fmpp.version>
         <forbiddenapis.version>3.10</forbiddenapis.version>
+        <freemarker.version>2.3.30</freemarker.version>
         <fusesource-mqtt-client.version>1.16</fusesource-mqtt-client.version>
         <google.java.format.version>1.28.0</google.java.format.version>
         <gson.version>2.13.1</gson.version>
@@ -962,11 +963,6 @@
                     <version>${antlr4.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.drill.tools</groupId>
-                    <artifactId>drill-fmpp-maven-plugin</artifactId>
-                    <version>${drill.freemarker.maven.plugin.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>3.3.2</version>
@@ -1681,6 +1677,92 @@
                                             </includes>
                                         </resource>
                                     </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>.fmpp-generation</id>
+            <activation>
+                <file>
+                    <exists>src/main/codegen</exists>
+                </file>
+            </activation>
+            <properties>
+                <fmpp.codegen.directory>${project.build.directory}/codegen</fmpp.codegen.directory>
+                <fmpp.output.directory>${project.build.directory}/generated-sources/freemarker</fmpp.output.directory>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <version>2.1.1</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.groovy</groupId>
+                                <artifactId>groovy</artifactId>
+                                <version>4.0.22</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>net.sourceforge.fmpp</groupId>
+                                <artifactId>fmpp</artifactId>
+                                <version>${fmpp.version}</version>
+                                <exclusions>
+                                    <!-- Supply only the pinned dependencies needed by our TDD/FreeMarker templates. -->
+                                    <exclusion>
+                                        <groupId>*</groupId>
+                                        <artifactId>*</artifactId>
+                                    </exclusion>
+                                </exclusions>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.freemarker</groupId>
+                                <artifactId>freemarker</artifactId>
+                                <version>${freemarker.version}</version>
+                            </dependency>
+                            <!-- FMPP links BeanShell classes when loading its settings engine. -->
+                            <dependency>
+                                <groupId>org.apache-extras.beanshell</groupId>
+                                <artifactId>bsh</artifactId>
+                                <version>2.0b6</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>oro</groupId>
+                                <artifactId>oro</artifactId>
+                                <version>2.0.8</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-fmpp</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${maven.multiModuleProjectDirectory}/src/main/groovy/generateFmpp.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-fmpp-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${fmpp.output.directory}</source>
+                                    </sources>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -923,9 +923,9 @@
                     <version>3.6.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.thrift</groupId>
-                    <artifactId>thrift-maven-plugin</artifactId>
-                    <version>0.10.0</version>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.bazaarvoice.maven.plugins</groupId>
@@ -1531,12 +1531,8 @@
         </profile>
         <!--
       Self activating profile, that activates itself as soon as a "src/main/thrift" directory is found.
-      The different plugins here download the thrift executable matching the current os, make that
-      executable (on mac and unix/linux) and run the code generation.
-
-      Note to the Download: The download-maven-plugin checks if a resource is previously downloaded
-      and only downloads each file once. It caches downloaded files in:
-      {maven local repo}/.cache/download-maven-plugin
+      The plugins unpack the Thrift compiler matching the current OS, generate sources and
+      package the local IDL files as resources.
     -->
         <profile>
             <id>.thrift-generation</id>
@@ -1577,58 +1573,67 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.thrift</groupId>
-                        <artifactId>thrift-maven-plugin</artifactId>
-                        <configuration>
-                            <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
-                            <thriftSourceRoot>${project.basedir}/src/main/thrift</thriftSourceRoot>
-                        </configuration>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>generate-thrift-sources-java</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
+                                <id>generate-thrift-sources</id>
                                 <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
                                 <configuration>
-                                    <generator>java:generated_annotations=suppress</generator>
+                                    <target>
+                                        <!-- Apply runs once per matching IDL without requiring a platform-specific shell. -->
+                                        <macrodef name="generate-thrift">
+                                            <attribute name="generator"/>
+                                            <attribute name="includes" default="**/*.thrift"/>
+                                            <attribute name="output"/>
+                                            <sequential>
+                                                <mkdir dir="@{output}"/>
+                                                <apply executable="${thrift.exec.absolute.path}" failonerror="true" skipemptyfilesets="true">
+                                                    <arg value="--gen"/>
+                                                    <arg value="@{generator}"/>
+                                                    <arg value="-I"/>
+                                                    <arg file="${project.basedir}/src/main/thrift"/>
+                                                    <arg value="-I"/>
+                                                    <!-- Read shared IDL from source so clean reactor builds do not need packaged dependency JARs. -->
+                                                    <arg file="${project.basedir}/../thrift-commons/src/main/thrift"/>
+                                                    <arg value="-out"/>
+                                                    <arg file="@{output}"/>
+                                                    <fileset dir="${project.basedir}/src/main/thrift" includes="@{includes}"/>
+                                                </apply>
+                                            </sequential>
+                                        </macrodef>
+                                        <generate-thrift generator="java:generated_annotations=suppress" output="${project.build.directory}/generated-sources/thrift"/>
+                                        <generate-thrift generator="py" includes="**/common.thrift,**/client.thrift,**/datanode.thrift,**/confignode.thrift,**/ainode.thrift" output="${project.build.directory}/generated-sources-python"/>
+                                        <generate-thrift generator="go:package_prefix=github.com/apache/iotdb-client-go/v2/" includes="**/common.thrift,**/client.thrift" output="${project.build.directory}/generated-sources-go"/>
+                                        <!-- Keep the shared output directory used when copying the C# client sources. -->
+                                        <generate-thrift generator="netstd:no_deepcopy" includes="**/common.thrift,**/client.thrift" output="${project.basedir}/../target/generated-sources-csharp"/>
+                                    </target>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
                             <execution>
-                                <id>generate-thrift-sources-python</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
+                                <id>add-thrift-resources</id>
                                 <phase>generate-sources</phase>
-                                <configuration>
-                                    <generator>py</generator>
-                                    <includes>**/common.thrift,**/client.thrift,**/datanode.thrift,**/confignode.thrift,**/ainode.thrift</includes>
-                                    <outputDirectory>${project.build.directory}/generated-sources-python/</outputDirectory>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>generate-thrift-sources-go</id>
                                 <goals>
-                                    <goal>compile</goal>
+                                    <goal>add-resource</goal>
                                 </goals>
-                                <phase>generate-sources</phase>
                                 <configuration>
-                                    <generator>go:package_prefix=github.com/apache/iotdb-client-go/v2/</generator>
-                                    <includes>**/common.thrift,**/client.thrift</includes>
-                                    <outputDirectory>${project.build.directory}/generated-sources-go</outputDirectory>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>generate-thrift-sources-csharp</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <phase>generate-sources</phase>
-                                <configuration>
-                                    <generator>netstd:no_deepcopy</generator>
-                                    <includes>**/common.thrift,**/client.thrift</includes>
-                                    <!-- The output directory is set to the parent of the generated sources for copying-->
-                                    <outputDirectory>${project.parent.build.directory}/generated-sources-csharp</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.basedir}/src/main/thrift</directory>
+                                            <includes>
+                                                <include>**/*.thrift</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/groovy/generateFmpp.groovy
+++ b/src/main/groovy/generateFmpp.groovy
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import fmpp.setting.Settings
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+// Each Maven module owns its output and uses a unique temporary directory.
+def codegen = Path.of(properties['fmpp.codegen.directory'].toString()).toAbsolutePath()
+def output = Path.of(properties['fmpp.output.directory'].toString()).toAbsolutePath()
+Files.createDirectories(output)
+def temporary = Files.createTempDirectory(output.parent, 'fmpp-')
+try {
+    def settings = new Settings(codegen.toFile())
+    settings.set(Settings.NAME_SOURCE_ROOT, codegen.resolve('templates').toString())
+    settings.set(Settings.NAME_OUTPUT_ROOT, temporary.toString())
+    settings.load(codegen.resolve('config.fmpp').toFile())
+    settings.execute()
+
+    // Publish only after every template succeeds; unchanged files retain their timestamps.
+    Files.walk(temporary).withCloseable { paths ->
+        paths.filter { Files.isRegularFile(it) }.forEach { generated ->
+            def destination = output.resolve(temporary.relativize(generated))
+            if (!Files.exists(destination) || Files.mismatch(generated, destination) != -1) {
+                Files.createDirectories(destination.parent)
+                Files.move(generated, destination, StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+    }
+} finally {
+    Files.walk(temporary).withCloseable { paths ->
+        paths.sorted(Comparator.reverseOrder()).forEach { Files.delete(it) }
+    }
+}


### PR DESCRIPTION
## Description

Replace `thrift-maven-plugin` and `drill-fmpp-maven-plugin` with generation configured in the parent POM, following [Apache Thrift's Maven guidance](https://github.com/apache/thrift/blob/master/lib/java/README.md#using-thrift-in-maven-projects) after https://github.com/apache/thrift/pull/3789.

Thrift generation uses `exec-maven-plugin` and `build-helper-maven-plugin`. Preserve the compiler download and override, generator options, Java/Python/Go/C# outputs, and IDL resources. Resolve shared IDL directly from source for clean reactor builds. Java source JARs retain Java and IDL files; they no longer bundle the generated Python/Go/C# files, which remain available in their existing output directories.

FMPP generation uses a shared Groovy script through the existing `groovy-maven-plugin`, with pinned FMPP and FreeMarker versions matching the previous generator. Generate into a unique temporary directory per invocation, publish only after all templates succeed, and replace only files whose contents changed. Unchanged files keep their timestamps. Each module owns its output, and generated Java source registration is centralized in the parent POM.

## Validation

On macOS ARM64 / JDK 17, with build caching disabled:

- All 50 default reactor modules passed clean `test-compile` with `-T 4` twice for both the original and modified versions, followed by incremental builds and full `package` builds.
- DataNode and its reactor dependencies passed clean `test-compile` with `-T 4` for both English and Chinese locales.
- Full clean `verify -Dmaven.test.skip=true -Dmdep.analyze.skip=true -P enable-sbom-check` passed. The SBOM Groovy execution remains root-only while FMPP generation is inherited by both template modules.
- All 636 Thrift outputs and 158 FMPP outputs are byte-for-byte identical to the original generators. All 18,371 production and 1,848 test class files are identical.
- Compared all 89 JARs and 10 ZIPs, including nested archives: runtime content differs only in embedded changed POMs. Source JAR differences are the intentional removal of non-Java Thrift sources and existing OpenAPI generation timestamps.
- Local checks passed for unchanged timestamps, selective updates, template failure before publishing, independent concurrent FMPP generation, and paths containing spaces. Test scripts are not included in this PR.
- A custom Thrift compiler path containing spaces succeeds; a compiler returning a nonzero exit status fails the build.
- Formatting checks and `git diff --check` passed.

- [x] This PR has been self-reviewed.
