### PR TITLE
Test TsFile 1.1.4 with IoTDB 1.3.8

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -49,4 +49,6 @@ jobs:
       - name: Compiler Test
         shell: bash
         run: |
-          mvn clean compile -P with-integration-tests -ntp
+          # These modules resolve ZIP/test artifacts that are only attached in the package phase.
+          # Exclude them here because this job intentionally stops at compile.
+          mvn clean compile -P with-integration-tests -ntp -pl '!distribution,!integration-test'

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileSourceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileSourceTest.java
@@ -210,6 +210,13 @@ public class PipeHistoricalDataRegionTsFileSourceTest {
     return resource;
   }
 
+  private static TsFileResource createTsFileResource(final File tempDir, final String fileName)
+      throws Exception {
+    final File file = new File(tempDir, fileName);
+    Assert.assertTrue(file.createNewFile());
+    return new TsFileResource(file);
+  }
+
   private static TsFileResource createClosedTsFileResourceWithDevices(
       final File tempDir, final String fileName, final String... devices) throws Exception {
     final TsFileResource resource =

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>tsfile-staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapachetsfile-1041</url>
+        </repository>
     </repositories>
     <parent>
         <groupId>org.apache</groupId>
@@ -165,7 +169,7 @@
         <thrift.version>0.23.0</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>1.1.4-260130-SNAPSHOT</tsfile.version>
+        <tsfile.version>1.1.4</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim


### PR DESCRIPTION
## Description

Use the Apache TsFile 1.1.4 RC1 artifacts with IoTDB 1.3.8 to validate compatibility:

- Add the TsFile staging repository: https://repository.apache.org/content/repositories/orgapachetsfile-1041/
- Change `tsfile.version` from `1.1.4-260130-SNAPSHOT` to `1.1.4`.

This is a test-only PR targeting `rc/1.3.8` and is not intended to be merged.

## Local validation

- Passed `mvn -B -ntp -N validate spotless:check` and `git diff --check`.
- Confirmed that DataNode, Session, JDBC, Consensus, and related modules resolve `org.apache.tsfile:tsfile:1.1.4` and `org.apache.tsfile:common:1.1.4` from the staging repository.
- Passed `mvn -B -ntp clean package -pl distribution -am -Dmaven.test.skip=true`; all 31 reactor modules built successfully and the IoTDB 1.3.8 distribution archives were generated.
- Passed DataNode `test-compile` after restoring the missing `createTsFileResource(File, String)` test helper.
- Passed the adjusted Compile Check command for all 43 applicable reactor modules.

## Test-only baseline workarounds

The `rc/1.3.8` base branch currently has two CI blockers unrelated to TsFile 1.1.4:

- DataNode test compilation is missing the `createTsFileResource(File, String)` helper (also reproduced on the base branch CI: https://github.com/apache/iotdb/actions/runs/34298324949).
- Compile Check runs only through Maven's `compile` phase, but `distribution` and `integration-test` consume ZIP/test artifacts attached later in `package`. Those two consumer modules are excluded from this compile-only job; the remaining 43 modules are still compiled.

This PR includes minimal test-only workarounds for both baseline issues so that the compatibility matrix can proceed. No IoTDB runtime code is changed.

The PR CI is the compatibility test matrix for this change.
