### PR TITLE
[Subscription] Suppress expected commit progress warnings

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
@@ -147,10 +147,13 @@ public class CommitProgressSyncProcedure extends AbstractOperateSubscriptionProc
     for (final Map.Entry<Integer, TPullCommitProgressResp> entry : respMap.entrySet()) {
       final TPullCommitProgressResp resp = entry.getValue();
       if (!isSuccessfulResponse(resp)) {
-        LOGGER.warn(
-            ProcedureMessages.LOG_FAILED_PULL_COMMIT_PROGRESS_DATANODE_ARG_STATUS_ARG_33037B29,
-            entry.getKey(),
-            Objects.isNull(resp) ? null : resp.getStatus());
+        // DataNodes with subscription disabled are expected to reject best-effort pulls.
+        if (!isUnsupportedOperationResponse(resp)) {
+          LOGGER.warn(
+              ProcedureMessages.LOG_FAILED_PULL_COMMIT_PROGRESS_DATANODE_ARG_STATUS_ARG_33037B29,
+              entry.getKey(),
+              Objects.isNull(resp) ? null : resp.getStatus());
+        }
         continue;
       }
       if (resp.isSetCommitRegionProgress()) {
@@ -190,6 +193,12 @@ public class CommitProgressSyncProcedure extends AbstractOperateSubscriptionProc
     return Objects.nonNull(response)
         && response.isSetStatus()
         && response.getStatus().getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode();
+  }
+
+  private static boolean isUnsupportedOperationResponse(final TPullCommitProgressResp response) {
+    return Objects.nonNull(response)
+        && response.isSetStatus()
+        && response.getStatus().getCode() == TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode();
   }
 
   @Override

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedureTest.java
@@ -32,14 +32,9 @@ import org.apache.iotdb.rpc.subscription.payload.poll.RegionProgress;
 import org.apache.iotdb.rpc.subscription.payload.poll.WriterId;
 import org.apache.iotdb.rpc.subscription.payload.poll.WriterProgress;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -80,7 +75,7 @@ public class CommitProgressSyncProcedureTest {
   }
 
   @Test
-  public void bestEffortSyncShouldOnlyWarnForUnexpectedResponses() throws Exception {
+  public void bestEffortSyncShouldSkipUnsuccessfulResponses() throws Exception {
     final String progressKey = "successful_progress";
     final RegionProgress progress =
         new RegionProgress(
@@ -116,25 +111,7 @@ public class CommitProgressSyncProcedureTest {
             subscriptionInfo = new AtomicReference<>(new SubscriptionInfo());
           }
         };
-    final Logger logger = (Logger) LoggerFactory.getLogger(CommitProgressSyncProcedure.class);
-    final Level originalLevel = logger.getLevel();
-    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
-    appender.start();
-    logger.addAppender(appender);
-    logger.setLevel(Level.WARN);
-    try {
-      procedure.executeFromOperateOnConfigNodes(env);
-
-      assertEquals(3, appender.list.size());
-      for (int i = 0; i < appender.list.size(); i++) {
-        assertEquals(Level.WARN, appender.list.get(i).getLevel());
-        assertEquals(i + 3, appender.list.get(i).getArgumentArray()[0]);
-      }
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-      logger.setLevel(originalLevel);
-    }
+    procedure.executeFromOperateOnConfigNodes(env);
 
     final ArgumentCaptor<CommitProgressHandleMetaChangePlan> planCaptor =
         ArgumentCaptor.forClass(CommitProgressHandleMetaChangePlan.class);

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedureTest.java
@@ -32,8 +32,14 @@ import org.apache.iotdb.rpc.subscription.payload.poll.RegionProgress;
 import org.apache.iotdb.rpc.subscription.payload.poll.WriterId;
 import org.apache.iotdb.rpc.subscription.payload.poll.WriterProgress;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -51,12 +57,15 @@ public class CommitProgressSyncProcedureTest {
 
   @Test
   public void requiredSyncShouldRejectFailedResponseBeforeConsensusWrite() throws Exception {
+    assertRequiredSyncRejectsResponse(TSStatusCode.EXECUTE_STATEMENT_ERROR);
+    assertRequiredSyncRejectsResponse(TSStatusCode.UNSUPPORTED_OPERATION);
+  }
+
+  private static void assertRequiredSyncRejectsResponse(final TSStatusCode statusCode)
+      throws Exception {
     final ConfigNodeProcedureEnv env = Mockito.mock(ConfigNodeProcedureEnv.class);
     final Map<Integer, TPullCommitProgressResp> responses = new LinkedHashMap<>();
-    responses.put(
-        2,
-        new TPullCommitProgressResp(
-            new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode())));
+    responses.put(2, new TPullCommitProgressResp(new TSStatus(statusCode.getStatusCode())));
     Mockito.when(env.pullCommitProgressFromDataNodes()).thenReturn(responses);
 
     try {
@@ -68,6 +77,72 @@ public class CommitProgressSyncProcedureTest {
     }
 
     Mockito.verify(env, Mockito.never()).getConfigManager();
+  }
+
+  @Test
+  public void bestEffortSyncShouldOnlyWarnForUnexpectedResponses() throws Exception {
+    final String progressKey = "successful_progress";
+    final RegionProgress progress =
+        new RegionProgress(
+            Collections.singletonMap(new WriterId("DataRegion[1]", 1), new WriterProgress(200, 1)));
+    final Map<Integer, TPullCommitProgressResp> responses = new LinkedHashMap<>();
+    responses.put(
+        1,
+        new TPullCommitProgressResp(
+            new TSStatus(TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode())));
+    responses.put(
+        2,
+        new TPullCommitProgressResp(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()))
+            .setCommitRegionProgress(Collections.singletonMap(progressKey, serialize(progress))));
+    responses.put(
+        3,
+        new TPullCommitProgressResp(
+            new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode())));
+    responses.put(4, null);
+    responses.put(5, new TPullCommitProgressResp());
+
+    final ConfigNodeProcedureEnv env = Mockito.mock(ConfigNodeProcedureEnv.class);
+    final ConfigManager configManager = Mockito.mock(ConfigManager.class);
+    final ConsensusManager consensusManager = Mockito.mock(ConsensusManager.class);
+    Mockito.when(env.pullCommitProgressFromDataNodesBestEffort()).thenReturn(responses);
+    Mockito.when(env.getConfigManager()).thenReturn(configManager);
+    Mockito.when(configManager.getConsensusManager()).thenReturn(consensusManager);
+    Mockito.when(consensusManager.write(Mockito.any()))
+        .thenReturn(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
+
+    final CommitProgressSyncProcedure procedure =
+        new CommitProgressSyncProcedure() {
+          {
+            subscriptionInfo = new AtomicReference<>(new SubscriptionInfo());
+          }
+        };
+    final Logger logger = (Logger) LoggerFactory.getLogger(CommitProgressSyncProcedure.class);
+    final Level originalLevel = logger.getLevel();
+    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.WARN);
+    try {
+      procedure.executeFromOperateOnConfigNodes(env);
+
+      assertEquals(3, appender.list.size());
+      for (int i = 0; i < appender.list.size(); i++) {
+        assertEquals(Level.WARN, appender.list.get(i).getLevel());
+        assertEquals(i + 3, appender.list.get(i).getArgumentArray()[0]);
+      }
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+      logger.setLevel(originalLevel);
+    }
+
+    final ArgumentCaptor<CommitProgressHandleMetaChangePlan> planCaptor =
+        ArgumentCaptor.forClass(CommitProgressHandleMetaChangePlan.class);
+    Mockito.verify(consensusManager).write(planCaptor.capture());
+    assertEquals(
+        progress,
+        RegionProgress.deserialize(planCaptor.getValue().getRegionProgressMap().get(progressKey)));
+    Mockito.verify(env, Mockito.never()).pullCommitProgressFromDataNodes();
   }
 
   @Test


### PR DESCRIPTION
## Description

DataNodes with `subscription_enabled=false` intentionally return `UNSUPPORTED_OPERATION` when
ConfigNode pulls commit progress. The best-effort synchronizer already ignores their progress but
then logs the expected response as a warning.

Suppress that expected status in the best-effort response loop. Other unsuccessful responses still
produce warnings, and required synchronization still rejects `UNSUPPORTED_OPERATION`.

## Validation

- `mvn spotless:apply -pl iotdb-core/confignode`
- `mvn -o test -pl iotdb-core/confignode -am -Dtest=CommitProgressSyncProcedureTest -Dsurefire.failIfNoSpecifiedTests=false -Ddevelocity.off=true`

The focused test covers expected and unexpected responses, required synchronization, and persistence
of progress from successful DataNodes.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `CommitProgressSyncProcedure`
