### PR TITLE
Fix sink user pipe visibility and mask credentials in SHOW CREATE PIPE

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/single/IoTDBPipePermissionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/single/IoTDBPipePermissionIT.java
@@ -115,7 +115,7 @@ public class IoTDBPipePermissionIT extends AbstractPipeSingleIT {
     try (final Connection connection = env.getConnection(BaseEnv.TABLE_SQL_DIALECT);
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b modify sink ('username'='thulab', 'password'='StrngPsWd@623451')");
+          "alter pipe a2b modify sink ('sink.username'='thulab', 'sink.password'='StrngPsWd@623451')");
     } catch (final SQLException e) {
       e.printStackTrace();
       fail("Alter pipe shall not fail if user and password are specified");
@@ -187,6 +187,13 @@ public class IoTDBPipePermissionIT extends AbstractPipeSingleIT {
       final ResultSet result = statement.executeQuery("show pipes");
       Assert.assertTrue(result.next());
       Assert.assertFalse(result.next());
+
+      final ResultSet showCreateResult = statement.executeQuery("show create pipe a2b");
+      Assert.assertTrue(showCreateResult.next());
+      Assert.assertTrue(
+          showCreateResult.getString("Create Pipe").contains("'sink.password'='******'"));
+      Assert.assertFalse(showCreateResult.getString("Create Pipe").contains("StrngPsWd@623451"));
+      Assert.assertFalse(showCreateResult.next());
     } catch (Exception e) {
       fail(e.getMessage());
     }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
@@ -179,10 +179,10 @@ public class PipeTableResp implements DataSet {
     return Objects.equals(
         userName,
         sinkParameters.getStringByKeys(
-            PipeSourceConstant.EXTRACTOR_IOTDB_USER_KEY,
-            PipeSourceConstant.SOURCE_IOTDB_USER_KEY,
-            PipeSourceConstant.EXTRACTOR_IOTDB_USERNAME_KEY,
-            PipeSourceConstant.SOURCE_IOTDB_USERNAME_KEY));
+            PipeSinkConstant.CONNECTOR_IOTDB_USER_KEY,
+            PipeSinkConstant.SINK_IOTDB_USER_KEY,
+            PipeSinkConstant.CONNECTOR_IOTDB_USERNAME_KEY,
+            PipeSinkConstant.SINK_IOTDB_USERNAME_KEY));
   }
 
   public TGetAllPipeInfoResp convertToTGetAllPipeInfoResp() throws IOException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/relational/ShowCreatePipeTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/relational/ShowCreatePipeTask.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.queryengine.common.header.DatasetHeaderFactory;
 import org.apache.iotdb.db.queryengine.plan.execution.config.ConfigTaskResult;
 import org.apache.iotdb.db.queryengine.plan.execution.config.IConfigTask;
 import org.apache.iotdb.db.queryengine.plan.execution.config.executor.IConfigTaskExecutor;
+import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -46,6 +47,8 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class ShowCreatePipeTask implements IConfigTask {
+
+  private static final String HIDDEN_VALUE = "******";
 
   private final String pipeName;
   private final String userName;
@@ -167,10 +170,12 @@ public class ShowCreatePipeTask implements IConfigTask {
     }
     final List<String> pairs = new ArrayList<>(attributes.size());
     for (final Map.Entry<String, String> entry : attributes.entrySet()) {
+      final String value =
+          PipeParameters.ValueHider.isHiddenKey(entry.getKey()) ? HIDDEN_VALUE : entry.getValue();
       pairs.add(
           ShowCreateTableTask.getString(entry.getKey())
               + "="
-              + ShowCreateTableTask.getString(entry.getValue()));
+              + ShowCreateTableTask.getString(value));
     }
     builder.append(" ").append(clause).append(" (").append(String.join(",", pairs)).append(")");
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/relational/ShowCreateTaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/relational/ShowCreateTaskTest.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ShowCreateTaskTest {
 
@@ -114,7 +115,7 @@ public class ShowCreateTaskTest {
   }
 
   @Test
-  public void testShowCreatePipeSQLShouldKeepExplicitCredentials() {
+  public void testShowCreatePipeSQLShouldMaskExplicitCredentials() {
     final Map<String, String> sourceAttributes = new HashMap<>();
     sourceAttributes.put(PipeSourceConstant.SOURCE_KEY, "iotdb-source");
     sourceAttributes.put(PipeSourceConstant.SOURCE_IOTDB_USERNAME_KEY, "alice");
@@ -136,13 +137,13 @@ public class ShowCreateTaskTest {
 
     assertEquals(
         "CREATE PIPE \"test_pipe\""
-            + " WITH SOURCE ('source'='iotdb-source','source.password'='secret','source.username'='alice')"
-            + " WITH SINK ('sink'='write-back-sink','sink.password'='secret','sink.username'='alice')",
+            + " WITH SOURCE ('source'='iotdb-source','source.password'='******','source.username'='alice')"
+            + " WITH SINK ('sink'='write-back-sink','sink.password'='******','sink.username'='alice')",
         ShowCreatePipeTask.getShowCreatePipeSQL(pipeMeta));
   }
 
   @Test
-  public void testShowCreatePipeSQLShouldKeepExplicitCredentialsWhenInjectionMarkerIsReset() {
+  public void testShowCreatePipeSQLShouldMaskExplicitCredentialsWhenInjectionMarkerIsReset() {
     final Map<String, String> sourceAttributes = new HashMap<>();
     sourceAttributes.put(PipeSourceConstant.SOURCE_KEY, "iotdb-source");
     sourceAttributes.put(PipeSourceConstant.SOURCE_IOTDB_USERNAME_KEY, "alice");
@@ -170,9 +171,42 @@ public class ShowCreateTaskTest {
 
     assertEquals(
         "CREATE PIPE \"test_pipe\""
-            + " WITH SOURCE ('source'='iotdb-source','source.password'='secret','source.username'='alice')"
-            + " WITH SINK ('sink'='write-back-sink','sink.password'='secret','sink.username'='alice')",
+            + " WITH SOURCE ('source'='iotdb-source','source.password'='******','source.username'='alice')"
+            + " WITH SINK ('sink'='write-back-sink','sink.password'='******','sink.username'='alice')",
         ShowCreatePipeTask.getShowCreatePipeSQL(pipeMeta));
+  }
+
+  @Test
+  public void testShowCreatePipeSQLShouldMaskSensitiveAliasAttributes() {
+    final Map<String, String> sourceAttributes = new HashMap<>();
+    sourceAttributes.put(PipeSourceConstant.EXTRACTOR_KEY, "iotdb-extractor");
+    sourceAttributes.put(PipeSourceConstant.EXTRACTOR_IOTDB_PASSWORD_KEY, "source-secret");
+    sourceAttributes.put("extractor.ssl.key-store-pwd", "key-store-secret");
+
+    final Map<String, String> sinkAttributes = new HashMap<>();
+    sinkAttributes.put(PipeSinkConstant.CONNECTOR_KEY, "iotdb-thrift-connector");
+    sinkAttributes.put(PipeSinkConstant.CONNECTOR_IOTDB_PASSWORD_KEY, "sink-secret");
+
+    final PipeMeta pipeMeta =
+        new PipeMeta(
+            new PipeStaticMeta("test_pipe", 1L, sourceAttributes, new HashMap<>(), sinkAttributes),
+            new PipeRuntimeMeta());
+
+    final String sql = ShowCreatePipeTask.getShowCreatePipeSQL(pipeMeta);
+    assertEquals(3, countOccurrences(sql, "******"));
+    assertFalse(sql.contains("source-secret"));
+    assertFalse(sql.contains("key-store-secret"));
+    assertFalse(sql.contains("sink-secret"));
+  }
+
+  private static int countOccurrences(final String value, final String searchedValue) {
+    int count = 0;
+    int index = 0;
+    while ((index = value.indexOf(searchedValue, index)) >= 0) {
+      count++;
+      index += searchedValue.length();
+    }
+    return count;
   }
 
   @Test


### PR DESCRIPTION
## Description

### Pipe visibility

- Fix write-back sink user visibility checks to read connector/sink authentication keys instead of extractor/source keys.
- Allow associated sink users to query the pipe through SHOW PIPES and SHOW CREATE PIPE.

### Credential masking

- Mask sensitive pipe attribute values in SHOW CREATE PIPE with the shared PipeParameters.ValueHider key rules.
- Cover source/sink passwords, extractor/connector aliases, and SSL credential keys.

### Tests

- Update ShowCreateTaskTest to verify explicit and alias-prefixed credentials are masked.
- Extend IoTDBPipePermissionIT to verify sink-user visibility and masked SHOW CREATE PIPE output.
- Passed targeted ShowCreateTaskTest (9 tests).
- Passed Spotless for ConfigNode, DataNode, and integration-test.
- Passed Checkstyle for ConfigNode and DataNode. Integration-test standalone Checkstyle is blocked by its existing unresolved baseDir configuration.
- The targeted integration-test reactor compiled the changed production modules, but could not reach the IT on this Windows host because existing generated-file RAT/dependency-analysis failures and JVM virtual-memory exhaustion interrupted the build.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or updated unit tests.
- [x] added integration tests.

<hr>

##### Key changed/added classes

- PipeTableResp
- ShowCreatePipeTask
- ShowCreateTaskTest
- IoTDBPipePermissionIT