### PR TITLE
[AINode] Add third-party attributions to binary package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -341,6 +341,38 @@ License: https://github.com/LMAX-Exchange/disruptor/blob/master/LICENCE.txt
 
 --------------------------------------------------------------------------------
 
+The following file includes code modified from GLIDE project.
+
+./iotdb-core/ainode/iotdb/ainode/core/model/sundial/flow_loss.py
+
+The GLIDE project is open source software licensed under the MIT License.
+Project page: https://github.com/openai/glide-text2im
+License: https://github.com/openai/glide-text2im/blob/main/LICENSE
+
+MIT License
+
+Copyright (c) 2021 OpenAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
 The following files include code modified from chronos-forecasting project.
 
 ./iotdb-core/ainode/iotdb/ainode/core/model/chronos2/*
@@ -348,6 +380,7 @@ The following files include code modified from chronos-forecasting project.
 The chronos-forecasting is open source software licensed under the Apache License 2.0
 Project page: https://github.com/amazon-science/chronos-forecasting
 License: https://github.com/amazon-science/chronos-forecasting/blob/main/LICENSE
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 --------------------------------------------------------------------------------
 
@@ -358,6 +391,7 @@ The following files include code modified from uni2ts project.
 The uni2ts is open source software licensed under the Apache License 2.0
 Project page: https://github.com/SalesforceAIResearch/uni2ts
 License: https://github.com/SalesforceAIResearch/uni2ts/blob/main/LICENSE.txt
+Copyright (c) 2024, Salesforce, Inc.
 
 --------------------------------------------------------------------------------
 

--- a/distribution/src/assembly/ainode-common-files.xml
+++ b/distribution/src/assembly/ainode-common-files.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<component xmlns="http://maven.apache.org/ASSEMBLY-COMPONENT/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/ASSEMBLY-COMPONENT/2.1.0 http://maven.apache.org/xsd/assembly-component-2.1.0.xsd">
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/../licenses</directory>
+            <outputDirectory>licenses</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../iotdb-core/ainode/src/assembly/resources/licenses</directory>
+            <outputDirectory>licenses</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${project.basedir}/../README.md</source>
+        </file>
+        <file>
+            <source>${project.basedir}/../README_ZH.md</source>
+        </file>
+        <file>
+            <source>${project.basedir}/../LICENSE-binary</source>
+            <destName>LICENSE</destName>
+        </file>
+        <file>
+            <source>${project.basedir}/../iotdb-core/ainode/src/assembly/resources/NOTICE-binary</source>
+            <destName>NOTICE</destName>
+        </file>
+        <file>
+            <source>${project.basedir}/../RELEASE_NOTES.md</source>
+        </file>
+    </files>
+</component>

--- a/distribution/src/assembly/ainode.xml
+++ b/distribution/src/assembly/ainode.xml
@@ -47,6 +47,6 @@
         </fileSet>
     </fileSets>
     <componentDescriptors>
-        <componentDescriptor>common-files.xml</componentDescriptor>
+        <componentDescriptor>ainode-common-files.xml</componentDescriptor>
     </componentDescriptors>
 </assembly>

--- a/iotdb-core/ainode/ainode.xml
+++ b/iotdb-core/ainode/ainode.xml
@@ -37,7 +37,7 @@
             <destName>LICENSE</destName>
         </file>
         <file>
-            <source>${maven.multiModuleProjectDirectory}/NOTICE-binary</source>
+            <source>src/assembly/resources/NOTICE-binary</source>
             <destName>NOTICE</destName>
         </file>
     </files>
@@ -59,6 +59,10 @@
             <directory>dist/ainode</directory>
             <outputDirectory>lib</outputDirectory>
             <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>src/assembly/resources/licenses</directory>
+            <outputDirectory>licenses</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../../scripts/sbin</directory>

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/__init__.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/__init__.py
@@ -15,3 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/base.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/base.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from enum import Enum
 from pathlib import Path

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/chronos_bolt.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/chronos_bolt.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import copy
 from dataclasses import dataclass

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/config.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/config.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from dataclasses import dataclass
 from typing import List, Literal

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/dataset.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/dataset.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import math
 from enum import Enum

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/layers.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/layers.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from dataclasses import dataclass
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/model.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/model.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import copy
 from dataclasses import dataclass

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/pipeline_chronos2.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/pipeline_chronos2.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/utils.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/chronos2/utils.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from typing import List
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/__init__.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/__init__.py
@@ -17,6 +17,8 @@
 #
 # This file is part of the Apache IoTDB project.
 #
-# This file includes code modified from the uni2ts project (https://github.com/salesforce/uni2ts).
-# The original code is licensed under the Apache License 2.0.
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
 #

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/common/torch_util.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/common/torch_util.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from typing import Optional
 
 import numpy as np

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/modeling_moirai2.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/modeling_moirai2.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import math
 import warnings
 from contextlib import contextmanager

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/attention.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/attention.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import math
 from collections.abc import Callable
 from functools import partial

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/ffn.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/ffn.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from collections.abc import Callable
 from typing import Optional
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/norm.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/norm.py
@@ -19,6 +19,7 @@
 # This file includes code modified from the uni2ts project:
 # https://github.com/SalesforceAIResearch/uni2ts
 # Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
 
 from typing import Optional
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/norm.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/norm.py
@@ -16,6 +16,10 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+
 from typing import Optional
 
 import torch

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/packed_scaler.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/packed_scaler.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from typing import Optional
 
 import torch

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/__init__.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/__init__.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from .additive import LearnedEmbedding, SinusoidalPositionEncoding
 from .attn_bias import (
     AttentionBias,

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/additive.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/additive.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import math
 
 import torch

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/attn_bias.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/attn_bias.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import abc
 
 import torch

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/attn_projection.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/position/attn_projection.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import abc
 import math
 from functools import cached_property

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/transformer.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/transformer.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from collections.abc import Callable
 from functools import partial
 from typing import Optional

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/ts_embed.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/module/ts_embed.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import math
 from typing import Optional
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/transform/_base.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/transform/_base.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 import abc
 from dataclasses import dataclass
 from typing import Any

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/transform/_mixin.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/transform/_mixin.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from collections.abc import Callable
 from typing import Any
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/transform/imputation.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moirai2/transform/imputation.py
@@ -16,6 +16,11 @@
 # under the License.
 #
 
+# This file includes code modified from the uni2ts project:
+# https://github.com/SalesforceAIResearch/uni2ts
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moment/configuration_moment.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moment/configuration_moment.py
@@ -19,6 +19,7 @@
 # This file contains code adapted from the MOMENT project
 # (https://github.com/moment-timeseries-foundation-model/moment),
 # originally licensed under the MIT License.
+# Copyright (c) 2024 Auton Lab, Carnegie Mellon University
 
 from typing import Optional
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moment/modeling_moment.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moment/modeling_moment.py
@@ -19,6 +19,7 @@
 # This file contains code adapted from the MOMENT project
 # (https://github.com/moment-timeseries-foundation-model/moment),
 # originally licensed under the MIT License.
+# Copyright (c) 2024 Auton Lab, Carnegie Mellon University
 
 import json
 import os

--- a/iotdb-core/ainode/iotdb/ainode/core/model/moment/pipeline_moment.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/moment/pipeline_moment.py
@@ -19,6 +19,7 @@
 # This file contains code adapted from the MOMENT project
 # (https://github.com/moment-timeseries-foundation-model/moment),
 # originally licensed under the MIT License.
+# Copyright (c) 2024 Auton Lab, Carnegie Mellon University
 
 import torch
 

--- a/iotdb-core/ainode/iotdb/ainode/core/model/sundial/flow_loss.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/model/sundial/flow_loss.py
@@ -98,7 +98,9 @@ class TimestepEmbedder(nn.Module):
         :param max_period: controls the minimum frequency of the embeddings.
         :return: an (N, D) Tensor of positional embeddings.
         """
+        # Adapted from GLIDE:
         # https://github.com/openai/glide-text2im/blob/main/glide_text2im/nn.py
+        # Copyright (c) 2021 OpenAI
         half = dim // 2
         freqs = torch.exp(
             -math.log(max_period)

--- a/iotdb-core/ainode/src/assembly/resources/NOTICE-binary
+++ b/iotdb-core/ainode/src/assembly/resources/NOTICE-binary
@@ -1,4 +1,4 @@
-Apache IoTDB
+Apache IoTDB AINode
 Copyright 2018-2026 The Apache Software Foundation.
 
 This product includes software developed at
@@ -19,10 +19,34 @@ grant the users the right to the use of patent under the requirement of Apache 2
 
 This product includes source code derived from the DataDog/toto project:
 
-  Toto – Timeseries-Optimized Transformer for Observability
+  Toto - Timeseries-Optimized Transformer for Observability
   Copyright 2025 Datadog, Inc.
   Licensed under the Apache License, Version 2.0
   https://github.com/DataDog/toto
+
+============================================================================
+
+This product includes source code modified from the GLIDE project:
+
+  Copyright (c) 2021 OpenAI
+  Licensed under the MIT License (see licenses/LICENSE-GLIDE)
+  https://github.com/openai/glide-text2im
+
+============================================================================
+
+This product includes source code modified from the MOMENT project:
+
+  Copyright (c) 2024 Auton Lab, Carnegie Mellon University
+  Licensed under the MIT License (see licenses/LICENSE-MOMENT)
+  https://github.com/moment-timeseries-foundation-model/moment
+
+============================================================================
+
+This product includes source code modified from the uni2ts project:
+
+  Copyright (c) 2024, Salesforce, Inc.
+  Licensed under the Apache License, Version 2.0
+  https://github.com/SalesforceAIResearch/uni2ts
 
 ============================================================================
 

--- a/iotdb-core/ainode/src/assembly/resources/licenses/LICENSE-GLIDE
+++ b/iotdb-core/ainode/src/assembly/resources/licenses/LICENSE-GLIDE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 OpenAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/iotdb-core/ainode/src/assembly/resources/licenses/LICENSE-MOMENT
+++ b/iotdb-core/ainode/src/assembly/resources/licenses/LICENSE-MOMENT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Auton Lab, Carnegie Mellon University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -766,6 +766,9 @@
                             <!-- bundled third-party NOTICE / license texts for the C++ client package -->
                             <exclude>**/package-metadata/third_party/NOTICE</exclude>
                             <exclude>**/package-metadata/third_party/licenses/**</exclude>
+                            <!-- bundled third-party NOTICE / license texts for the AINode package -->
+                            <exclude>**/ainode/src/assembly/resources/NOTICE-binary</exclude>
+                            <exclude>**/ainode/src/assembly/resources/licenses/**</exclude>
                             <!-- only for Travis CI with WinOS-->
                             <exclude>hadoopbin</exclude>
                             <exclude>windowssystem32</exclude>


### PR DESCRIPTION
## Description

This is a follow-up to #18611. That PR adds the full MOMENT MIT text to the source release root `LICENSE`; this PR covers the AINode binary packaging path and the related pre-existing attribution gaps found during review.

- bundle the full GLIDE and MOMENT MIT license texts in AINode binary packages
- use an AINode-specific `NOTICE` in both the module and distribution assemblies
- carry the Chronos Amazon NOTICE into source and AINode binary distributions, and restore the upstream copyright/SPDX headers in the adapted Chronos2 sources
- retain the upstream copyrights for the adapted GLIDE, MOMENT, and uni2ts code
- add the full GLIDE MIT text to the source-release `LICENSE`

The AINode-specific assembly metadata keeps these attributions out of unrelated IoTDB binary artifacts. The separate DiT/`FinalLayer` provenance work is intentionally not included here.

## Verification

- `black --check .` and `isort --check-only --profile black .` in `iotdb-core/ainode`
- `mvn apache-rat:check -DskipTests`
- `mvn -P with-ainode -pl iotdb-core/ainode apache-rat:check -DskipTests`
- XML validation with `xmllint`
- Python syntax validation with `compileall`
- exercised both AINode assembly descriptors with a fixture payload; the module ZIP and final `ainode-bin` ZIP contained the AINode-specific `NOTICE`, `licenses/LICENSE-GLIDE`, and `licenses/LICENSE-MOMENT`, with byte-identical packaged contents
